### PR TITLE
簡化 Docker 部署的方式

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Certimate 旨在为用户提供一个安全、简便的 SSL 证书管理解决�
 
 ```bash
 
-git clone git@github.com:usual2970/certimate.git && cd certimate/docker && docker compose up -d
+mkdir -p ~/.certimate && cd ~/.certimate && curl -O https://raw.githubusercontent.com/usual2970/certimate/refs/heads/main/docker/docker-compose.yml && docker compose up -d
 
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -47,7 +47,7 @@ You can download the precompiled binary files directly from the [Releases page](
 
 ```bash
 
-git clone git@github.com:usual2970/certimate.git && cd certimate/docker && docker compose up -d
+mkdir -p ~/.certimate && cd ~/.certimate && curl -O https://raw.githubusercontent.com/usual2970/certimate/refs/heads/main/docker/docker-compose.yml && docker compose up -d
 
 ```
 


### PR DESCRIPTION
Old Ver: 在原有的方式下通過 Docker 進行部署時會將整個倉庫進行 clone 到本地的操作
New Ver: 更新後的 Readme 文件中指出將僅進行對 docker-compose.yml 文件的下載操作，同時仍可滿足使用 Docker 部署的要求