### PR TITLE
change: tencent ssl upload repeatable to false

### DIFF
--- a/internal/deployer/tencent_cdn.go
+++ b/internal/deployer/tencent_cdn.go
@@ -76,7 +76,7 @@ func (t *tencentCdn) uploadCert() (string, error) {
 	request.CertificatePublicKey = common.StringPtr(t.option.Certificate.Certificate)
 	request.CertificatePrivateKey = common.StringPtr(t.option.Certificate.PrivateKey)
 	request.Alias = common.StringPtr(t.option.Domain + "_" + rand.RandStr(6))
-	request.Repeatable = common.BoolPtr(true)
+	request.Repeatable = common.BoolPtr(false)
 
 	response, err := client.UploadCertificate(request)
 	if err != nil {


### PR DESCRIPTION
腾讯云ssl证书上传接口可重复选项设置为`false`，以避免重复上传导致的列表污染。

经测试，该项修改为`false`后返回值中`response.Response.CertificateId`为现有重复的证书`CertificateId`，可正常用于后续部署动作。