### PR TITLE
feat: reamdme里面的源码启动命令已经失效，因为ui/dist不在代码仓库中管理

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,4 @@ help:
 .PHONY: all build clean help
 
 local.run:
-	go mod vendor&& npm --prefix ./ui install && npm --prefix ./ui run build && go run main.go serve
+	go mod vendor&& npm --prefix ./ui install && npm --prefix ./ui run build && go run main.go serve --http 127.0.0.1:8090

--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,6 @@ help:
 	@echo "  make help   - 显示此帮助信息"
 
 .PHONY: all build clean help
+
+local.run:
+	go mod vendor&& npm --prefix ./ui install && npm --prefix ./ui run build && go run main.go serve

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ mkdir -p ~/.certimate && cd ~/.certimate && curl -O https://raw.githubuserconten
 ```bash
 git clone EMAIL:usual2970/certimate.git
 cd certimate
-go mod vendor
-go run main.go serve
+make local.run
 ```
 
 ## 二、使用

--- a/README_EN.md
+++ b/README_EN.md
@@ -54,8 +54,7 @@ mkdir -p ~/.certimate && cd ~/.certimate && curl -O https://raw.githubuserconten
 ```bash
 git clone EMAIL:usual2970/certimate.git
 cd certimate
-go mod vendor
-go run main.go serve
+make local.run
 ```
 
 ## Usage

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"os"
 	"strings"
@@ -25,6 +26,12 @@ func main() {
 
 	isGoRun := strings.HasPrefix(os.Args[0], os.TempDir())
 
+	// 获取启动命令中的http参数
+	var httpFlag string
+	flag.StringVar(&httpFlag, "http", "127.0.0.1:8090", "HTTP server address")
+	// "serve"影响解析
+	_ = flag.CommandLine.Parse(os.Args[2:])
+
 	migratecmd.MustRegister(app, app.RootCmd, migratecmd.Config{
 		// enable auto creation of migration files when making collection changes in the Admin UI
 		// (the isGoRun check is to enable it only during development)
@@ -48,7 +55,7 @@ func main() {
 	})
 
 	defer log.Println("Exit!")
-	log.Println("Visit the website:", "http://127.0.0.1:8090")
+	log.Printf("Visit the website: http://%s", httpFlag)
 
 	if err := app.Start(); err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -46,10 +46,9 @@ func main() {
 
 		return nil
 	})
+
 	defer log.Println("Exit!")
-	go func() {
-		log.Println("Visit the website:", "http://127.0.0.1:8090")
-	}()
+	log.Println("Visit the website:", "http://127.0.0.1:8090")
 
 	if err := app.Start(); err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/usual2970/certimate/ui"
 	"log"
 	"os"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"github.com/usual2970/certimate/internal/domains"
 	"github.com/usual2970/certimate/internal/routes"
 	"github.com/usual2970/certimate/internal/utils/app"
+	"github.com/usual2970/certimate/ui"
 
 	_ "time/tzdata"
 )
@@ -46,6 +46,10 @@ func main() {
 
 		return nil
 	})
+	defer log.Println("Exit!")
+	go func() {
+		log.Println("Visit the website:", "http://127.0.0.1:8090")
+	}()
 
 	if err := app.Start(); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
1.更新reamdme，确保源码安装方式下能支持启动；
2.更新main.go，增加启动和退出的文案提示；
3.更新makefile,一条命令启动项目。