### PR TITLE
修复腾讯云cdn和ecdn控制台融合后，只部署cdn域名的问题

### DIFF
--- a/internal/deployer/tencent_cdn.go
+++ b/internal/deployer/tencent_cdn.go
@@ -130,13 +130,29 @@ func (d *TencentCDNDeployer) getDomainList() ([]string, error) {
 
 	cert := base64.StdEncoding.EncodeToString([]byte(d.option.Certificate.Certificate))
 	request.Cert = &cert
+	domains := make([]string, 0)
+
+	var product string
+	product = "cdn"
+	request.Product = &product
 
 	response, err := client.DescribeCertDomains(request)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get domain list: %w", err)
+		return nil, fmt.Errorf("failed to get cdn domain list: %w", err)
 	}
 
-	domains := make([]string, 0)
+	for _, domain := range response.Response.Domains {
+		domains = append(domains, *domain)
+	}
+
+	product = "ecdn"
+	request.Product = &product
+
+	response, err = client.DescribeCertDomains(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ecdn domain list: %w", err)
+	}
+
 	for _, domain := range response.Response.Domains {
 		domains = append(domains, *domain)
 	}


### PR DESCRIPTION
在获取域名列表的时候，Product参数分别各传入cdn和ecdn一次，然后拼接出完整的域名列表