### PR TITLE
feat: k8s部署支持ServiceAccount权限

### DIFF
--- a/ui/src/components/certimate/AccessKubernetesForm.tsx
+++ b/ui/src/components/certimate/AccessKubernetesForm.tsx
@@ -37,7 +37,7 @@ const AccessKubernetesForm = ({ data, op, onAfterReq }: AccessKubernetesFormProp
     configType: accessTypeFormSchema,
     kubeConfig: z
       .string()
-      .min(1, "access.authorization.form.k8s_kubeconfig.placeholder")
+      .min(0, "access.authorization.form.k8s_kubeconfig.placeholder")
       .max(20480, t("common.errmsg.string_max", { max: 20480 })),
     kubeConfigFile: z.any().optional(),
   });
@@ -191,3 +191,4 @@ const AccessKubernetesForm = ({ data, op, onAfterReq }: AccessKubernetesFormProp
 };
 
 export default AccessKubernetesForm;
+

--- a/ui/src/i18n/locales/en/nls.access.json
+++ b/ui/src/i18n/locales/en/nls.access.json
@@ -69,9 +69,9 @@
   "access.authorization.form.ssh_key_passphrase.placeholder": "Please enter Key Passphrase",
   "access.authorization.form.webhook_url.label": "Webhook URL",
   "access.authorization.form.webhook_url.placeholder": "Please enter Webhook URL",
-  "access.authorization.form.k8s_kubeconfig.label": "KubeConfig",
+  "access.authorization.form.k8s_kubeconfig.label": "KubeConfig (Null will use pod's ServiceAccount)",
   "access.authorization.form.k8s_kubeconfig.placeholder": "Please enter KubeConfig",
-  "access.authorization.form.k8s_kubeconfig_file.placeholder": "Please select file",
+  "access.authorization.form.k8s_kubeconfig_file.placeholder": "Please select file (Null will use pod's ServiceAccount)",
 
   "access.group.tab": "Authorization Group",
 

--- a/ui/src/i18n/locales/zh/nls.access.json
+++ b/ui/src/i18n/locales/zh/nls.access.json
@@ -69,7 +69,7 @@
   "access.authorization.form.ssh_key_passphrase.placeholder": "请输入 Key 口令",
   "access.authorization.form.webhook_url.label": "Webhook URL",
   "access.authorization.form.webhook_url.placeholder": "请输入 Webhook URL",
-  "access.authorization.form.k8s_kubeconfig.label": "KubeConfig",
+  "access.authorization.form.k8s_kubeconfig.label": "KubeConfig（不选将使用Pod的ServiceAccount）",
   "access.authorization.form.k8s_kubeconfig.placeholder": "请输入 KubeConfig",
   "access.authorization.form.k8s_kubeconfig_file.placeholder": "请选择文件",
 


### PR DESCRIPTION
使部署在k8s中的 `certimate` 没有 `kubeconfig` 也可以部署证书。
k8s部署的 `certimate` Pod 需要有 写 Secret 权限的 ServiceAccount, 如下

```yaml
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: certimate
rules:
  - apiGroups: [""]
    resources:
      - secrets
    verbs:
      - get
      - create
      - update
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: certimate
  namespace: default
  labels:
    app: certimate
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: certimate
subjects:
  - kind: ServiceAccount
    name: certimate
    namespace: default
roleRef:
  kind: ClusterRole
  name: certimate
  apiGroup: rbac.authorization.k8s.io
---
kind: Deployment
apiVersion: apps/v1
metadata:
  labels:
    app: certimate
  name: certimate
spec:
  selector:
    matchLabels:
      app: certimate
  template:
    metadata:
      labels:
        app: certimate
    spec:
      serviceAccount: certimate
      serviceAccountName: certimate
      containers:
        - name: certimate
          image: registry.cn-shanghai.aliyuncs.com/usual2970/certimate:latest
          ports:
            - containerPort: 8090
              protocol: TCP
          volumeMounts:
            - mountPath: /app/pb_data
              name: volume-data
      volumes:
        - name: volume-data
          persistentVolumeClaim:
            claimName: certimate-pvc

```