### PR TITLE
fix: tencent cos ui locales loss

### DIFF
--- a/ui/src/components/certimate/DeployToTencentCOS.tsx
+++ b/ui/src/components/certimate/DeployToTencentCOS.tsx
@@ -79,11 +79,11 @@ const DeployToTencentCOS = () => {
   });
 
   const regionSchema = z.string().regex(/^ap-[a-z]+$/, {
-    message: t("domain.deployment.form.cos_region.placeholder"),
+    message: t("domain.deployment.form.tencent_cos_region.placeholder"),
   });
 
   const bucketSchema = z.string().regex(/^.+-\d+$/, {
-    message: t("domain.deployment.form.cos_bucket.placeholder"),
+    message: t("domain.deployment.form.tencent_cos_bucket.placeholder"),
   });
 
   return (


### PR DESCRIPTION
修正腾讯云COS部署表单之前由 https://github.com/usual2970/certimate/commit/024b3c936e7d0492efa0bc9cad3beffa1f722826 回滚导致的验证提示丢失文本映射的问题