### PR TITLE
feat: 使系统设置中的消息推送设置列表打开后能够关闭

### DIFF
--- a/ui/src/pages/setting/Notify.tsx
+++ b/ui/src/pages/setting/Notify.tsx
@@ -29,7 +29,7 @@ const Notify = () => {
         </div>
 
         <div className="border rounded-md p-5 mt-7 shadow-lg">
-          <Accordion type={"single"} className="dark:text-stone-200">
+          <Accordion type={"single"} collapsible={true} className="dark:text-stone-200">
             <AccordionItem value="item-email" className="dark:border-stone-200">
               <AccordionTrigger>{t("common.provider.email")}</AccordionTrigger>
               <AccordionContent>


### PR DESCRIPTION
### 更新原因
在设置消息推送时，发现下方推送渠道设置打开后无法关闭，体验不好，因此在保留原有**只能同时打开一个项目**的逻辑下，新增**打开项目可以关闭**逻辑。
<img width="1790" alt="image" src="https://github.com/user-attachments/assets/6d5a5cb5-20b0-4b68-bcd7-4b217e9d8319">

