### PR TITLE
Update NotifyChannelEditFormDingTalkFields.tsx

### DIFF
--- a/ui/src/components/notification/NotifyChannelEditFormDingTalkFields.tsx
+++ b/ui/src/components/notification/NotifyChannelEditFormDingTalkFields.tsx
@@ -14,7 +14,7 @@ const NotifyChannelEditFormDingTalkFields = () => {
     secret: z
       .string({ message: t("settings.notification.channel.form.dingtalk_secret.placeholder") })
       .min(1, t("settings.notification.channel.form.dingtalk_secret.placeholder"))
-      .max(64, t("common.errmsg.string_max", { max: 64 })),
+      .max(128, t("common.errmsg.string_max", { max: 128 })),
   });
   const formRule = createSchemaFieldRule(formSchema);
 


### PR DESCRIPTION
fix: 钉钉机器人的密钥是 67 个字符