### PR TITLE
bugfix: tencent cloud ecdn deploy error 

### DIFF
--- a/internal/pkg/core/deployer/providers/tencentcloud-ecdn/tencentcloud_ecdn.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-ecdn/tencentcloud_ecdn.go
@@ -107,7 +107,7 @@ func (d *DeployerProvider) Deploy(ctx context.Context, certPem string, privkeyPe
 		// REF: https://cloud.tencent.com/document/product/400/91667
 		deployCertificateInstanceReq := tcssl.NewDeployCertificateInstanceRequest()
 		deployCertificateInstanceReq.CertificateId = common.StringPtr(upres.CertId)
-		deployCertificateInstanceReq.ResourceType = common.StringPtr("ecdn")
+		deployCertificateInstanceReq.ResourceType = common.StringPtr("cdn")
 		deployCertificateInstanceReq.Status = common.Int64Ptr(1)
 		deployCertificateInstanceReq.InstanceIdList = common.StringPtrs(instanceIds)
 		deployCertificateInstanceResp, err := d.sdkClients.SSL.DeployCertificateInstance(deployCertificateInstanceReq)


### PR DESCRIPTION
ECDN部署的时候报错：`failed to execute sdk request 'ssl.DeployCertificateInstance':[TencentCloudSDKError] Code=FailedOperation.CertificateHostResourceTypeInvalid, Message=云资源类型无效。` 经排查 `ssl.DeployCertificateInstance` 接口的ResourceType不支持ecdn类型，ecdn和cdn都需要传入cdn