### PR TITLE
style: format with gofumpt

### DIFF
--- a/internal/applicant/acme_ca.go
+++ b/internal/applicant/acme_ca.go
@@ -1,4 +1,4 @@
-﻿package applicant
+package applicant
 
 import "github.com/usual2970/certimate/internal/domain"
 

--- a/internal/applicant/acme_user.go
+++ b/internal/applicant/acme_user.go
@@ -1,4 +1,4 @@
-﻿package applicant
+package applicant
 
 import (
 	"context"

--- a/internal/domain/dtos/certificate.go
+++ b/internal/domain/dtos/certificate.go
@@ -1,4 +1,4 @@
-﻿package dtos
+package dtos
 
 type CertificateArchiveFileReq struct {
 	CertificateId string `json:"-"`

--- a/internal/domain/dtos/notify.go
+++ b/internal/domain/dtos/notify.go
@@ -1,4 +1,4 @@
-﻿package dtos
+package dtos
 
 import "github.com/usual2970/certimate/internal/domain"
 

--- a/internal/domain/dtos/workflow.go
+++ b/internal/domain/dtos/workflow.go
@@ -1,4 +1,4 @@
-﻿package dtos
+package dtos
 
 import "github.com/usual2970/certimate/internal/domain"
 

--- a/internal/domain/provider.go
+++ b/internal/domain/provider.go
@@ -1,4 +1,4 @@
-﻿package domain
+package domain
 
 type AccessProviderType string
 

--- a/internal/pkg/core/applicant/acme-dns-01/lego-providers/acmehttpreq/acmehttpreq.go
+++ b/internal/pkg/core/applicant/acme-dns-01/lego-providers/acmehttpreq/acmehttpreq.go
@@ -1,4 +1,4 @@
-﻿package acmehttpreq
+package acmehttpreq
 
 import (
 	"net/url"

--- a/internal/pkg/core/applicant/acme-dns-01/lego-providers/baiducloud/internal/lego.go
+++ b/internal/pkg/core/applicant/acme-dns-01/lego-providers/baiducloud/internal/lego.go
@@ -1,4 +1,4 @@
-﻿package lego_baiducloud
+package lego_baiducloud
 
 import (
 	"errors"

--- a/internal/pkg/core/applicant/acme-dns-01/lego-providers/dnsla/internal/lego.go
+++ b/internal/pkg/core/applicant/acme-dns-01/lego-providers/dnsla/internal/lego.go
@@ -1,4 +1,4 @@
-﻿package lego_dnsla
+package lego_dnsla
 
 import (
 	"errors"

--- a/internal/pkg/core/applicant/acme-dns-01/lego-providers/dynv6/internal/lego.go
+++ b/internal/pkg/core/applicant/acme-dns-01/lego-providers/dynv6/internal/lego.go
@@ -1,4 +1,4 @@
-﻿package lego_dynv6
+package lego_dynv6
 
 import (
 	"context"

--- a/internal/pkg/core/applicant/acme-dns-01/lego-providers/gname/internal/lego.go
+++ b/internal/pkg/core/applicant/acme-dns-01/lego-providers/gname/internal/lego.go
@@ -1,4 +1,4 @@
-﻿package lego_gname
+package lego_gname
 
 import (
 	"errors"

--- a/internal/pkg/core/applicant/acme-dns-01/lego-providers/jdcloud/internal/lego.go
+++ b/internal/pkg/core/applicant/acme-dns-01/lego-providers/jdcloud/internal/lego.go
@@ -1,4 +1,4 @@
-﻿package lego_jdcloud
+package lego_jdcloud
 
 import (
 	"errors"

--- a/internal/pkg/core/applicant/acme-dns-01/lego-providers/tencentcloud-eo/internal/lego.go
+++ b/internal/pkg/core/applicant/acme-dns-01/lego-providers/tencentcloud-eo/internal/lego.go
@@ -1,4 +1,4 @@
-﻿package lego_tencentcloudeo
+package lego_tencentcloudeo
 
 import (
 	"errors"

--- a/internal/pkg/core/deployer/deployer.go
+++ b/internal/pkg/core/deployer/deployer.go
@@ -1,4 +1,4 @@
-﻿package deployer
+package deployer
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/1panel-console/1panel_console.go
+++ b/internal/pkg/core/deployer/providers/1panel-console/1panel_console.go
@@ -1,4 +1,4 @@
-﻿package onepanelconsole
+package onepanelconsole
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/1panel-console/1panel_console_test.go
+++ b/internal/pkg/core/deployer/providers/1panel-console/1panel_console_test.go
@@ -1,4 +1,4 @@
-﻿package onepanelconsole_test
+package onepanelconsole_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/1panel-site/1panel_site.go
+++ b/internal/pkg/core/deployer/providers/1panel-site/1panel_site.go
@@ -1,4 +1,4 @@
-﻿package onepanelsite
+package onepanelsite
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/1panel-site/1panel_site_test.go
+++ b/internal/pkg/core/deployer/providers/1panel-site/1panel_site_test.go
@@ -1,4 +1,4 @@
-﻿package onepanelsite_test
+package onepanelsite_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-alb/aliyun_alb.go
+++ b/internal/pkg/core/deployer/providers/aliyun-alb/aliyun_alb.go
@@ -1,4 +1,4 @@
-﻿package aliyunalb
+package aliyunalb
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-alb/aliyun_alb_test.go
+++ b/internal/pkg/core/deployer/providers/aliyun-alb/aliyun_alb_test.go
@@ -1,4 +1,4 @@
-﻿package aliyunalb_test
+package aliyunalb_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-alb/consts.go
+++ b/internal/pkg/core/deployer/providers/aliyun-alb/consts.go
@@ -1,4 +1,4 @@
-﻿package aliyunalb
+package aliyunalb
 
 type ResourceType string
 

--- a/internal/pkg/core/deployer/providers/aliyun-cas-deploy/aliyun_cas_deploy.go
+++ b/internal/pkg/core/deployer/providers/aliyun-cas-deploy/aliyun_cas_deploy.go
@@ -1,4 +1,4 @@
-﻿package aliyuncasdeploy
+package aliyuncasdeploy
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-cas/aliyun_cas.go
+++ b/internal/pkg/core/deployer/providers/aliyun-cas/aliyun_cas.go
@@ -1,4 +1,4 @@
-﻿package aliyuncas
+package aliyuncas
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-cdn/aliyun_cdn.go
+++ b/internal/pkg/core/deployer/providers/aliyun-cdn/aliyun_cdn.go
@@ -1,4 +1,4 @@
-﻿package aliyuncdn
+package aliyuncdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-cdn/aliyun_cdn_test.go
+++ b/internal/pkg/core/deployer/providers/aliyun-cdn/aliyun_cdn_test.go
@@ -1,4 +1,4 @@
-﻿package aliyuncdn_test
+package aliyuncdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-clb/aliyun_clb.go
+++ b/internal/pkg/core/deployer/providers/aliyun-clb/aliyun_clb.go
@@ -1,4 +1,4 @@
-﻿package aliyunclb
+package aliyunclb
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-clb/aliyun_clb_test.go
+++ b/internal/pkg/core/deployer/providers/aliyun-clb/aliyun_clb_test.go
@@ -1,4 +1,4 @@
-﻿package aliyunclb_test
+package aliyunclb_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-clb/consts.go
+++ b/internal/pkg/core/deployer/providers/aliyun-clb/consts.go
@@ -1,4 +1,4 @@
-﻿package aliyunclb
+package aliyunclb
 
 type ResourceType string
 

--- a/internal/pkg/core/deployer/providers/aliyun-dcdn/aliyun_dcdn.go
+++ b/internal/pkg/core/deployer/providers/aliyun-dcdn/aliyun_dcdn.go
@@ -1,4 +1,4 @@
-﻿package aliyundcdn
+package aliyundcdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-dcdn/aliyun_dcdn_test.go
+++ b/internal/pkg/core/deployer/providers/aliyun-dcdn/aliyun_dcdn_test.go
@@ -1,4 +1,4 @@
-﻿package aliyundcdn_test
+package aliyundcdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-esa/aliyun_esa.go
+++ b/internal/pkg/core/deployer/providers/aliyun-esa/aliyun_esa.go
@@ -1,4 +1,4 @@
-﻿package aliyunesa
+package aliyunesa
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-esa/aliyun_esa_test.go
+++ b/internal/pkg/core/deployer/providers/aliyun-esa/aliyun_esa_test.go
@@ -1,4 +1,4 @@
-﻿package aliyunesa_test
+package aliyunesa_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-fc/aliyun_fc.go
+++ b/internal/pkg/core/deployer/providers/aliyun-fc/aliyun_fc.go
@@ -1,4 +1,4 @@
-﻿package aliyunfc
+package aliyunfc
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-fc/aliyun_fc_test.go
+++ b/internal/pkg/core/deployer/providers/aliyun-fc/aliyun_fc_test.go
@@ -1,4 +1,4 @@
-﻿package aliyunfc_test
+package aliyunfc_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-live/aliyun_live.go
+++ b/internal/pkg/core/deployer/providers/aliyun-live/aliyun_live.go
@@ -1,4 +1,4 @@
-﻿package aliyunlive
+package aliyunlive
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-live/aliyun_live_test.go
+++ b/internal/pkg/core/deployer/providers/aliyun-live/aliyun_live_test.go
@@ -1,4 +1,4 @@
-﻿package aliyunlive_test
+package aliyunlive_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-nlb/aliyun_nlb.go
+++ b/internal/pkg/core/deployer/providers/aliyun-nlb/aliyun_nlb.go
@@ -1,4 +1,4 @@
-﻿package aliyunnlb
+package aliyunnlb
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-nlb/aliyun_nlb_test.go
+++ b/internal/pkg/core/deployer/providers/aliyun-nlb/aliyun_nlb_test.go
@@ -1,4 +1,4 @@
-﻿package aliyunnlb_test
+package aliyunnlb_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-nlb/consts.go
+++ b/internal/pkg/core/deployer/providers/aliyun-nlb/consts.go
@@ -1,4 +1,4 @@
-﻿package aliyunnlb
+package aliyunnlb
 
 type ResourceType string
 

--- a/internal/pkg/core/deployer/providers/aliyun-oss/aliyun_oss.go
+++ b/internal/pkg/core/deployer/providers/aliyun-oss/aliyun_oss.go
@@ -1,4 +1,4 @@
-﻿package aliyunoss
+package aliyunoss
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-oss/aliyun_oss_test.go
+++ b/internal/pkg/core/deployer/providers/aliyun-oss/aliyun_oss_test.go
@@ -1,4 +1,4 @@
-﻿package aliyunoss_test
+package aliyunoss_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-vod/aliyun_vod.go
+++ b/internal/pkg/core/deployer/providers/aliyun-vod/aliyun_vod.go
@@ -1,4 +1,4 @@
-﻿package aliyunvod
+package aliyunvod
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-vod/aliyun_vod_test.go
+++ b/internal/pkg/core/deployer/providers/aliyun-vod/aliyun_vod_test.go
@@ -1,4 +1,4 @@
-﻿package aliyunvod_test
+package aliyunvod_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-waf/aliyun_waf.go
+++ b/internal/pkg/core/deployer/providers/aliyun-waf/aliyun_waf.go
@@ -1,4 +1,4 @@
-﻿package aliyunwaf
+package aliyunwaf
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aliyun-waf/aliyun_waf_test.go
+++ b/internal/pkg/core/deployer/providers/aliyun-waf/aliyun_waf_test.go
@@ -1,4 +1,4 @@
-﻿package aliyunwaf_test
+package aliyunwaf_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aws-acm/aws_acm.go
+++ b/internal/pkg/core/deployer/providers/aws-acm/aws_acm.go
@@ -1,4 +1,4 @@
-﻿package awsacm
+package awsacm
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aws-cloudfront/aws_cloudfront.go
+++ b/internal/pkg/core/deployer/providers/aws-cloudfront/aws_cloudfront.go
@@ -1,4 +1,4 @@
-﻿package awscloudfront
+package awscloudfront
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/aws-cloudfront/aws_cloudfront_test.go
+++ b/internal/pkg/core/deployer/providers/aws-cloudfront/aws_cloudfront_test.go
@@ -1,4 +1,4 @@
-﻿package awscloudfront_test
+package awscloudfront_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/azure-keyvault/azure_keyvault.go
+++ b/internal/pkg/core/deployer/providers/azure-keyvault/azure_keyvault.go
@@ -1,4 +1,4 @@
-﻿package azurekeyvault
+package azurekeyvault
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/baiducloud-appblb/baiducloud_appblb.go
+++ b/internal/pkg/core/deployer/providers/baiducloud-appblb/baiducloud_appblb.go
@@ -1,4 +1,4 @@
-﻿package baiducloudappblb
+package baiducloudappblb
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/baiducloud-appblb/baiducloud_appblb_test.go
+++ b/internal/pkg/core/deployer/providers/baiducloud-appblb/baiducloud_appblb_test.go
@@ -1,4 +1,4 @@
-﻿package baiducloudappblb_test
+package baiducloudappblb_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/baiducloud-appblb/consts.go
+++ b/internal/pkg/core/deployer/providers/baiducloud-appblb/consts.go
@@ -1,4 +1,4 @@
-﻿package baiducloudappblb
+package baiducloudappblb
 
 type ResourceType string
 

--- a/internal/pkg/core/deployer/providers/baiducloud-blb/baiducloud_blb.go
+++ b/internal/pkg/core/deployer/providers/baiducloud-blb/baiducloud_blb.go
@@ -1,4 +1,4 @@
-﻿package baiducloudblb
+package baiducloudblb
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/baiducloud-blb/baiducloud_blb_test.go
+++ b/internal/pkg/core/deployer/providers/baiducloud-blb/baiducloud_blb_test.go
@@ -1,4 +1,4 @@
-﻿package baiducloudblb_test
+package baiducloudblb_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/baiducloud-blb/consts.go
+++ b/internal/pkg/core/deployer/providers/baiducloud-blb/consts.go
@@ -1,4 +1,4 @@
-﻿package baiducloudblb
+package baiducloudblb
 
 type ResourceType string
 

--- a/internal/pkg/core/deployer/providers/baiducloud-cdn/baiducloud_cdn.go
+++ b/internal/pkg/core/deployer/providers/baiducloud-cdn/baiducloud_cdn.go
@@ -1,4 +1,4 @@
-﻿package baiducloudcdn
+package baiducloudcdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/baiducloud-cdn/baiducloud_cdn_test.go
+++ b/internal/pkg/core/deployer/providers/baiducloud-cdn/baiducloud_cdn_test.go
@@ -1,4 +1,4 @@
-﻿package baiducloudcdn_test
+package baiducloudcdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/baiducloud-cert/baiducloud_cert.go
+++ b/internal/pkg/core/deployer/providers/baiducloud-cert/baiducloud_cert.go
@@ -1,4 +1,4 @@
-﻿package baiducloudcert
+package baiducloudcert
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/baishan-cdn/baishan_cdn.go
+++ b/internal/pkg/core/deployer/providers/baishan-cdn/baishan_cdn.go
@@ -1,4 +1,4 @@
-﻿package baishancdn
+package baishancdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/baishan-cdn/baishan_cdn_test.go
+++ b/internal/pkg/core/deployer/providers/baishan-cdn/baishan_cdn_test.go
@@ -1,4 +1,4 @@
-﻿package baishancdn_test
+package baishancdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/baotapanel-console/baotapanel_console.go
+++ b/internal/pkg/core/deployer/providers/baotapanel-console/baotapanel_console.go
@@ -1,4 +1,4 @@
-﻿package baotapanelconsole
+package baotapanelconsole
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/baotapanel-console/baotapanel_console_test.go
+++ b/internal/pkg/core/deployer/providers/baotapanel-console/baotapanel_console_test.go
@@ -1,4 +1,4 @@
-﻿package baotapanelconsole_test
+package baotapanelconsole_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/baotapanel-site/baotapanel_site.go
+++ b/internal/pkg/core/deployer/providers/baotapanel-site/baotapanel_site.go
@@ -1,4 +1,4 @@
-﻿package baotapanelsite
+package baotapanelsite
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/baotapanel-site/baotapanel_site_test.go
+++ b/internal/pkg/core/deployer/providers/baotapanel-site/baotapanel_site_test.go
@@ -1,4 +1,4 @@
-﻿package baotapanelsite_test
+package baotapanelsite_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/byteplus-cdn/byteplus_cdn.go
+++ b/internal/pkg/core/deployer/providers/byteplus-cdn/byteplus_cdn.go
@@ -1,4 +1,4 @@
-﻿package bytepluscdn
+package bytepluscdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/byteplus-cdn/byteplus_cdn_test.go
+++ b/internal/pkg/core/deployer/providers/byteplus-cdn/byteplus_cdn_test.go
@@ -1,4 +1,4 @@
-﻿package bytepluscdn_test
+package bytepluscdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/cachefly/cachefly.go
+++ b/internal/pkg/core/deployer/providers/cachefly/cachefly.go
@@ -1,4 +1,4 @@
-﻿package cachefly
+package cachefly
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/cachefly/cachefly_test.go
+++ b/internal/pkg/core/deployer/providers/cachefly/cachefly_test.go
@@ -1,4 +1,4 @@
-﻿package cachefly_test
+package cachefly_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/cdnfly/cdnfly.go
+++ b/internal/pkg/core/deployer/providers/cdnfly/cdnfly.go
@@ -1,4 +1,4 @@
-﻿package cdnfly
+package cdnfly
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/cdnfly/cdnfly_test.go
+++ b/internal/pkg/core/deployer/providers/cdnfly/cdnfly_test.go
@@ -1,4 +1,4 @@
-﻿package cdnfly_test
+package cdnfly_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/cdnfly/consts.go
+++ b/internal/pkg/core/deployer/providers/cdnfly/consts.go
@@ -1,4 +1,4 @@
-﻿package cdnfly
+package cdnfly
 
 type ResourceType string
 

--- a/internal/pkg/core/deployer/providers/dogecloud-cdn/dogecloud_cdn.go
+++ b/internal/pkg/core/deployer/providers/dogecloud-cdn/dogecloud_cdn.go
@@ -1,4 +1,4 @@
-﻿package dogecloudcdn
+package dogecloudcdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/dogecloud-cdn/dogecloud_cdn_test.go
+++ b/internal/pkg/core/deployer/providers/dogecloud-cdn/dogecloud_cdn_test.go
@@ -1,4 +1,4 @@
-﻿package dogecloudcdn_test
+package dogecloudcdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/edgio-applications/edgio_applications.go
+++ b/internal/pkg/core/deployer/providers/edgio-applications/edgio_applications.go
@@ -1,4 +1,4 @@
-﻿package edgioapplications
+package edgioapplications
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/edgio-applications/edgio_applications_test.go
+++ b/internal/pkg/core/deployer/providers/edgio-applications/edgio_applications_test.go
@@ -1,4 +1,4 @@
-﻿package edgioapplications_test
+package edgioapplications_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/gcore-cdn/gcore_cdn.go
+++ b/internal/pkg/core/deployer/providers/gcore-cdn/gcore_cdn.go
@@ -1,4 +1,4 @@
-﻿package gcorecdn
+package gcorecdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/gcore-cdn/gcore_cdn_test.go
+++ b/internal/pkg/core/deployer/providers/gcore-cdn/gcore_cdn_test.go
@@ -1,4 +1,4 @@
-﻿package gcorecdn_test
+package gcorecdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/huaweicloud-cdn/huaweicloud_cdn.go
+++ b/internal/pkg/core/deployer/providers/huaweicloud-cdn/huaweicloud_cdn.go
@@ -1,4 +1,4 @@
-﻿package huaweicloudcdn
+package huaweicloudcdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/huaweicloud-cdn/huaweicloud_cdn_test.go
+++ b/internal/pkg/core/deployer/providers/huaweicloud-cdn/huaweicloud_cdn_test.go
@@ -1,4 +1,4 @@
-﻿package huaweicloudcdn_test
+package huaweicloudcdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/huaweicloud-elb/consts.go
+++ b/internal/pkg/core/deployer/providers/huaweicloud-elb/consts.go
@@ -1,4 +1,4 @@
-﻿package huaweicloudelb
+package huaweicloudelb
 
 type ResourceType string
 

--- a/internal/pkg/core/deployer/providers/huaweicloud-elb/huaweicloud_elb.go
+++ b/internal/pkg/core/deployer/providers/huaweicloud-elb/huaweicloud_elb.go
@@ -1,4 +1,4 @@
-﻿package huaweicloudelb
+package huaweicloudelb
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/huaweicloud-elb/huaweicloud_elb_test.go
+++ b/internal/pkg/core/deployer/providers/huaweicloud-elb/huaweicloud_elb_test.go
@@ -1,4 +1,4 @@
-﻿package huaweicloudelb_test
+package huaweicloudelb_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/huaweicloud-scm/huaweicloud_scm.go
+++ b/internal/pkg/core/deployer/providers/huaweicloud-scm/huaweicloud_scm.go
@@ -1,4 +1,4 @@
-﻿package huaweicloudscm
+package huaweicloudscm
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/huaweicloud-waf/consts.go
+++ b/internal/pkg/core/deployer/providers/huaweicloud-waf/consts.go
@@ -1,4 +1,4 @@
-﻿package huaweicloudwaf
+package huaweicloudwaf
 
 type ResourceType string
 

--- a/internal/pkg/core/deployer/providers/huaweicloud-waf/huaweicloud_waf.go
+++ b/internal/pkg/core/deployer/providers/huaweicloud-waf/huaweicloud_waf.go
@@ -1,4 +1,4 @@
-﻿package huaweicloudwaf
+package huaweicloudwaf
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/huaweicloud-waf/huaweicloud_waf_test.go
+++ b/internal/pkg/core/deployer/providers/huaweicloud-waf/huaweicloud_waf_test.go
@@ -1,4 +1,4 @@
-﻿package huaweicloudwaf_test
+package huaweicloudwaf_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/jdcloud-alb/consts.go
+++ b/internal/pkg/core/deployer/providers/jdcloud-alb/consts.go
@@ -1,4 +1,4 @@
-﻿package jdcloudalb
+package jdcloudalb
 
 type ResourceType string
 

--- a/internal/pkg/core/deployer/providers/jdcloud-alb/jdcloud_alb.go
+++ b/internal/pkg/core/deployer/providers/jdcloud-alb/jdcloud_alb.go
@@ -1,4 +1,4 @@
-﻿package jdcloudalb
+package jdcloudalb
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/jdcloud-alb/jdcloud_alb_test.go
+++ b/internal/pkg/core/deployer/providers/jdcloud-alb/jdcloud_alb_test.go
@@ -1,4 +1,4 @@
-﻿package jdcloudalb_test
+package jdcloudalb_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/jdcloud-cdn/jdcloud_cdn.go
+++ b/internal/pkg/core/deployer/providers/jdcloud-cdn/jdcloud_cdn.go
@@ -1,4 +1,4 @@
-﻿package jdcloudcdn
+package jdcloudcdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/jdcloud-cdn/jdcloud_cdn_test.go
+++ b/internal/pkg/core/deployer/providers/jdcloud-cdn/jdcloud_cdn_test.go
@@ -1,4 +1,4 @@
-﻿package jdcloudcdn_test
+package jdcloudcdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/jdcloud-live/jdcloud_live.go
+++ b/internal/pkg/core/deployer/providers/jdcloud-live/jdcloud_live.go
@@ -1,4 +1,4 @@
-﻿package jdcloudlive
+package jdcloudlive
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/jdcloud-live/jdcloud_live_test.go
+++ b/internal/pkg/core/deployer/providers/jdcloud-live/jdcloud_live_test.go
@@ -1,4 +1,4 @@
-﻿package jdcloudlive_test
+package jdcloudlive_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/jdcloud-vod/jdcloud_vod.go
+++ b/internal/pkg/core/deployer/providers/jdcloud-vod/jdcloud_vod.go
@@ -1,4 +1,4 @@
-﻿package jdcloudvod
+package jdcloudvod
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/jdcloud-vod/jdcloud_vod_test.go
+++ b/internal/pkg/core/deployer/providers/jdcloud-vod/jdcloud_vod_test.go
@@ -1,4 +1,4 @@
-﻿package jdcloudvod_test
+package jdcloudvod_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/k8s-secret/k8s_secret.go
+++ b/internal/pkg/core/deployer/providers/k8s-secret/k8s_secret.go
@@ -1,4 +1,4 @@
-﻿package k8ssecret
+package k8ssecret
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/k8s-secret/k8s_secret_test.go
+++ b/internal/pkg/core/deployer/providers/k8s-secret/k8s_secret_test.go
@@ -1,4 +1,4 @@
-﻿package k8ssecret_test
+package k8ssecret_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/local/defines.go
+++ b/internal/pkg/core/deployer/providers/local/defines.go
@@ -1,4 +1,4 @@
-﻿package local
+package local
 
 type OutputFormatType string
 

--- a/internal/pkg/core/deployer/providers/local/local.go
+++ b/internal/pkg/core/deployer/providers/local/local.go
@@ -1,4 +1,4 @@
-﻿package local
+package local
 
 import (
 	"bytes"

--- a/internal/pkg/core/deployer/providers/local/local_test.go
+++ b/internal/pkg/core/deployer/providers/local/local_test.go
@@ -1,4 +1,4 @@
-﻿package local_test
+package local_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/qiniu-cdn/qiniu_cdn.go
+++ b/internal/pkg/core/deployer/providers/qiniu-cdn/qiniu_cdn.go
@@ -1,4 +1,4 @@
-﻿package qiniucdn
+package qiniucdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/qiniu-cdn/qiniu_cdn_test.go
+++ b/internal/pkg/core/deployer/providers/qiniu-cdn/qiniu_cdn_test.go
@@ -1,4 +1,4 @@
-﻿package qiniucdn_test
+package qiniucdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/qiniu-pili/qiniu_pili.go
+++ b/internal/pkg/core/deployer/providers/qiniu-pili/qiniu_pili.go
@@ -1,4 +1,4 @@
-﻿package qiniupili
+package qiniupili
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/qiniu-pili/qiniu_pili_test.go
+++ b/internal/pkg/core/deployer/providers/qiniu-pili/qiniu_pili_test.go
@@ -1,4 +1,4 @@
-﻿package qiniupili_test
+package qiniupili_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/safeline/consts.go
+++ b/internal/pkg/core/deployer/providers/safeline/consts.go
@@ -1,4 +1,4 @@
-﻿package safeline
+package safeline
 
 type ResourceType string
 

--- a/internal/pkg/core/deployer/providers/safeline/safeline.go
+++ b/internal/pkg/core/deployer/providers/safeline/safeline.go
@@ -1,4 +1,4 @@
-﻿package safeline
+package safeline
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/safeline/safeline_test.go
+++ b/internal/pkg/core/deployer/providers/safeline/safeline_test.go
@@ -1,4 +1,4 @@
-﻿package safeline_test
+package safeline_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/ssh/defines.go
+++ b/internal/pkg/core/deployer/providers/ssh/defines.go
@@ -1,4 +1,4 @@
-﻿package ssh
+package ssh
 
 type OutputFormatType string
 

--- a/internal/pkg/core/deployer/providers/ssh/ssh.go
+++ b/internal/pkg/core/deployer/providers/ssh/ssh.go
@@ -1,4 +1,4 @@
-﻿package ssh
+package ssh
 
 import (
 	"bytes"

--- a/internal/pkg/core/deployer/providers/ssh/ssh_test.go
+++ b/internal/pkg/core/deployer/providers/ssh/ssh_test.go
@@ -1,4 +1,4 @@
-﻿package ssh_test
+package ssh_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-cdn/tencentcloud_cdn.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-cdn/tencentcloud_cdn.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudcdn
+package tencentcloudcdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-cdn/tencentcloud_cdn_test.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-cdn/tencentcloud_cdn_test.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudcdn_test
+package tencentcloudcdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-clb/consts.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-clb/consts.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudclb
+package tencentcloudclb
 
 type ResourceType string
 

--- a/internal/pkg/core/deployer/providers/tencentcloud-clb/tencentcloud_clb.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-clb/tencentcloud_clb.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudclb
+package tencentcloudclb
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-clb/tencentcloud_clb_test.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-clb/tencentcloud_clb_test.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudclb_test
+package tencentcloudclb_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-cos/tencentcloud_cos.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-cos/tencentcloud_cos.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudcos
+package tencentcloudcos
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-cos/tencentcloud_cos_test.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-cos/tencentcloud_cos_test.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudcos_test
+package tencentcloudcos_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-css/tencentcloud_css.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-css/tencentcloud_css.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudcss
+package tencentcloudcss
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-css/tencentcloud_css_test.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-css/tencentcloud_css_test.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudcss_test
+package tencentcloudcss_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-ecdn/tencentcloud_ecdn.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-ecdn/tencentcloud_ecdn.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudecdn
+package tencentcloudecdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-ecdn/tencentcloud_ecdn_test.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-ecdn/tencentcloud_ecdn_test.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudecdn_test
+package tencentcloudecdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-eo/tencentcloud_eo.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-eo/tencentcloud_eo.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudeo
+package tencentcloudeo
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-eo/tencentcloud_eo_test.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-eo/tencentcloud_eo_test.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudeo_test
+package tencentcloudeo_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-scf/tencentcloud_scf.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-scf/tencentcloud_scf.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudscf
+package tencentcloudscf
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-scf/tencentcloud_scf_test.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-scf/tencentcloud_scf_test.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudscf_test
+package tencentcloudscf_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-ssl-deploy/tencentcloud_ssl_deploy.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-ssl-deploy/tencentcloud_ssl_deploy.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudssldeploy
+package tencentcloudssldeploy
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-ssl/tencentcloud_ssl.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-ssl/tencentcloud_ssl.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudssl
+package tencentcloudssl
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-vod/tencentcloud_vod.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-vod/tencentcloud_vod.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudvod
+package tencentcloudvod
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-vod/tencentcloud_vod_test.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-vod/tencentcloud_vod_test.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudvod_test
+package tencentcloudvod_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-waf/tencentcloud_waf.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-waf/tencentcloud_waf.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudwaf
+package tencentcloudwaf
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/tencentcloud-waf/tencentcloud_waf_test.go
+++ b/internal/pkg/core/deployer/providers/tencentcloud-waf/tencentcloud_waf_test.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudwaf_test
+package tencentcloudwaf_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/ucloud-ucdn/ucloud_ucdn.go
+++ b/internal/pkg/core/deployer/providers/ucloud-ucdn/ucloud_ucdn.go
@@ -1,4 +1,4 @@
-﻿package uclouducdn
+package uclouducdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/ucloud-ucdn/ucloud_ucdn_test.go
+++ b/internal/pkg/core/deployer/providers/ucloud-ucdn/ucloud_ucdn_test.go
@@ -1,4 +1,4 @@
-﻿package uclouducdn_test
+package uclouducdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/ucloud-us3/ucloud_us3.go
+++ b/internal/pkg/core/deployer/providers/ucloud-us3/ucloud_us3.go
@@ -1,4 +1,4 @@
-﻿package ucloudus3
+package ucloudus3
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/ucloud-us3/ucloud_us3_test.go
+++ b/internal/pkg/core/deployer/providers/ucloud-us3/ucloud_us3_test.go
@@ -1,4 +1,4 @@
-﻿package ucloudus3_test
+package ucloudus3_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/upyun-cdn/upyun_cdn.go
+++ b/internal/pkg/core/deployer/providers/upyun-cdn/upyun_cdn.go
@@ -1,4 +1,4 @@
-﻿package upyuncdn
+package upyuncdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/upyun-cdn/upyun_cdn_test.go
+++ b/internal/pkg/core/deployer/providers/upyun-cdn/upyun_cdn_test.go
@@ -1,4 +1,4 @@
-﻿package upyuncdn_test
+package upyuncdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-alb/consts.go
+++ b/internal/pkg/core/deployer/providers/volcengine-alb/consts.go
@@ -1,4 +1,4 @@
-﻿package volcenginealb
+package volcenginealb
 
 type ResourceType string
 

--- a/internal/pkg/core/deployer/providers/volcengine-alb/volcengine_alb.go
+++ b/internal/pkg/core/deployer/providers/volcengine-alb/volcengine_alb.go
@@ -1,4 +1,4 @@
-﻿package volcenginealb
+package volcenginealb
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-alb/volcengine_alb_test.go
+++ b/internal/pkg/core/deployer/providers/volcengine-alb/volcengine_alb_test.go
@@ -1,4 +1,4 @@
-﻿package volcenginealb_test
+package volcenginealb_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-cdn/volcengine_cdn.go
+++ b/internal/pkg/core/deployer/providers/volcengine-cdn/volcengine_cdn.go
@@ -1,4 +1,4 @@
-﻿package volcenginecdn
+package volcenginecdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-cdn/volcengine_cdn_test.go
+++ b/internal/pkg/core/deployer/providers/volcengine-cdn/volcengine_cdn_test.go
@@ -1,4 +1,4 @@
-﻿package volcenginecdn_test
+package volcenginecdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-certcenter/volcengine_certcenter.go
+++ b/internal/pkg/core/deployer/providers/volcengine-certcenter/volcengine_certcenter.go
@@ -1,4 +1,4 @@
-﻿package volcenginecertcenter
+package volcenginecertcenter
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-clb/consts.go
+++ b/internal/pkg/core/deployer/providers/volcengine-clb/consts.go
@@ -1,4 +1,4 @@
-﻿package volcengineclb
+package volcengineclb
 
 type ResourceType string
 

--- a/internal/pkg/core/deployer/providers/volcengine-clb/volcengine_clb.go
+++ b/internal/pkg/core/deployer/providers/volcengine-clb/volcengine_clb.go
@@ -1,4 +1,4 @@
-﻿package volcengineclb
+package volcengineclb
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-clb/volcengine_clb_test.go
+++ b/internal/pkg/core/deployer/providers/volcengine-clb/volcengine_clb_test.go
@@ -1,4 +1,4 @@
-﻿package volcengineclb_test
+package volcengineclb_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-dcdn/volcengine_dcdn.go
+++ b/internal/pkg/core/deployer/providers/volcengine-dcdn/volcengine_dcdn.go
@@ -1,4 +1,4 @@
-﻿package volcenginedcdn
+package volcenginedcdn
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-dcdn/volcengine_dcdn_test.go
+++ b/internal/pkg/core/deployer/providers/volcengine-dcdn/volcengine_dcdn_test.go
@@ -1,4 +1,4 @@
-﻿package volcenginedcdn_test
+package volcenginedcdn_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-imagex/volcengine_imagex.go
+++ b/internal/pkg/core/deployer/providers/volcengine-imagex/volcengine_imagex.go
@@ -1,4 +1,4 @@
-﻿package volcengineimagex
+package volcengineimagex
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-imagex/volcengine_imagex_test.go
+++ b/internal/pkg/core/deployer/providers/volcengine-imagex/volcengine_imagex_test.go
@@ -1,4 +1,4 @@
-﻿package volcengineimagex_test
+package volcengineimagex_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-live/volcengine_live.go
+++ b/internal/pkg/core/deployer/providers/volcengine-live/volcengine_live.go
@@ -1,4 +1,4 @@
-﻿package volcenginelive
+package volcenginelive
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-live/volcengine_live_test.go
+++ b/internal/pkg/core/deployer/providers/volcengine-live/volcengine_live_test.go
@@ -1,4 +1,4 @@
-﻿package volcenginelive_test
+package volcenginelive_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-tos/volcengine_tos.go
+++ b/internal/pkg/core/deployer/providers/volcengine-tos/volcengine_tos.go
@@ -1,4 +1,4 @@
-﻿package volcenginetos
+package volcenginetos
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/volcengine-tos/volcengine_tos_test.go
+++ b/internal/pkg/core/deployer/providers/volcengine-tos/volcengine_tos_test.go
@@ -1,4 +1,4 @@
-﻿package volcenginetos_test
+package volcenginetos_test
 
 import (
 	"context"

--- a/internal/pkg/core/deployer/providers/webhook/webhook_test.go
+++ b/internal/pkg/core/deployer/providers/webhook/webhook_test.go
@@ -1,4 +1,4 @@
-﻿package webhook_test
+package webhook_test
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/bark/bark.go
+++ b/internal/pkg/core/notifier/providers/bark/bark.go
@@ -1,4 +1,4 @@
-﻿package bark
+package bark
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/bark/bark_test.go
+++ b/internal/pkg/core/notifier/providers/bark/bark_test.go
@@ -1,4 +1,4 @@
-﻿package bark_test
+package bark_test
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/dingtalk/dingtalk.go
+++ b/internal/pkg/core/notifier/providers/dingtalk/dingtalk.go
@@ -1,4 +1,4 @@
-﻿package dingtalk
+package dingtalk
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/dingtalk/dingtalk_test.go
+++ b/internal/pkg/core/notifier/providers/dingtalk/dingtalk_test.go
@@ -1,4 +1,4 @@
-﻿package dingtalk_test
+package dingtalk_test
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/email/email.go
+++ b/internal/pkg/core/notifier/providers/email/email.go
@@ -1,4 +1,4 @@
-﻿package email
+package email
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/email/email_test.go
+++ b/internal/pkg/core/notifier/providers/email/email_test.go
@@ -1,4 +1,4 @@
-﻿package email_test
+package email_test
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/lark/lark.go
+++ b/internal/pkg/core/notifier/providers/lark/lark.go
@@ -1,4 +1,4 @@
-﻿package lark
+package lark
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/lark/lark_test.go
+++ b/internal/pkg/core/notifier/providers/lark/lark_test.go
@@ -1,4 +1,4 @@
-﻿package lark_test
+package lark_test
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/serverchan/serverchan.go
+++ b/internal/pkg/core/notifier/providers/serverchan/serverchan.go
@@ -1,4 +1,4 @@
-﻿package serverchan
+package serverchan
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/serverchan/serverchan_test.go
+++ b/internal/pkg/core/notifier/providers/serverchan/serverchan_test.go
@@ -1,4 +1,4 @@
-﻿package serverchan_test
+package serverchan_test
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/telegram/telegram.go
+++ b/internal/pkg/core/notifier/providers/telegram/telegram.go
@@ -1,4 +1,4 @@
-﻿package telegram
+package telegram
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/telegram/telegram_test.go
+++ b/internal/pkg/core/notifier/providers/telegram/telegram_test.go
@@ -1,4 +1,4 @@
-﻿package telegram_test
+package telegram_test
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/webhook/webhook.go
+++ b/internal/pkg/core/notifier/providers/webhook/webhook.go
@@ -1,4 +1,4 @@
-﻿package webhook
+package webhook
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/webhook/webhook_test.go
+++ b/internal/pkg/core/notifier/providers/webhook/webhook_test.go
@@ -1,4 +1,4 @@
-﻿package webhook_test
+package webhook_test
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/wecom/wecom.go
+++ b/internal/pkg/core/notifier/providers/wecom/wecom.go
@@ -1,4 +1,4 @@
-﻿package serverchan
+package serverchan
 
 import (
 	"context"

--- a/internal/pkg/core/notifier/providers/wecom/wecom_test.go
+++ b/internal/pkg/core/notifier/providers/wecom/wecom_test.go
@@ -1,4 +1,4 @@
-﻿package serverchan_test
+package serverchan_test
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/1panel-ssl/1panel_ssl.go
+++ b/internal/pkg/core/uploader/providers/1panel-ssl/1panel_ssl.go
@@ -1,4 +1,4 @@
-﻿package onepanelssl
+package onepanelssl
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/1panel-ssl/1panel_ssl_test.go
+++ b/internal/pkg/core/uploader/providers/1panel-ssl/1panel_ssl_test.go
@@ -1,4 +1,4 @@
-﻿package onepanelssl_test
+package onepanelssl_test
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/aliyun-cas/aliyun_cas.go
+++ b/internal/pkg/core/uploader/providers/aliyun-cas/aliyun_cas.go
@@ -1,4 +1,4 @@
-﻿package aliyuncas
+package aliyuncas
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/aliyun-slb/aliyun_slb.go
+++ b/internal/pkg/core/uploader/providers/aliyun-slb/aliyun_slb.go
@@ -1,4 +1,4 @@
-﻿package aliyunslb
+package aliyunslb
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/aws-acm/aws_acm.go
+++ b/internal/pkg/core/uploader/providers/aws-acm/aws_acm.go
@@ -1,4 +1,4 @@
-﻿package awsacm
+package awsacm
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/azure-keyvault/azure_keyvault.go
+++ b/internal/pkg/core/uploader/providers/azure-keyvault/azure_keyvault.go
@@ -1,4 +1,4 @@
-﻿package azurekeyvault
+package azurekeyvault
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/baiducloud-cert/baiducloud_cert.go
+++ b/internal/pkg/core/uploader/providers/baiducloud-cert/baiducloud_cert.go
@@ -1,4 +1,4 @@
-﻿package baiducloudcert
+package baiducloudcert
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/baiducloud-cert/baiducloud_cert_test.go
+++ b/internal/pkg/core/uploader/providers/baiducloud-cert/baiducloud_cert_test.go
@@ -1,4 +1,4 @@
-﻿package baiducloudcert_test
+package baiducloudcert_test
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/dogecloud/dogecloud.go
+++ b/internal/pkg/core/uploader/providers/dogecloud/dogecloud.go
@@ -1,4 +1,4 @@
-﻿package dogecloud
+package dogecloud
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/gcore-cdn/gcore_cdn.go
+++ b/internal/pkg/core/uploader/providers/gcore-cdn/gcore_cdn.go
@@ -1,4 +1,4 @@
-﻿package gcorecdn
+package gcorecdn
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/huaweicloud-elb/huaweicloud_elb.go
+++ b/internal/pkg/core/uploader/providers/huaweicloud-elb/huaweicloud_elb.go
@@ -1,4 +1,4 @@
-﻿package huaweicloudelb
+package huaweicloudelb
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/huaweicloud-scm/huaweicloud_scm.go
+++ b/internal/pkg/core/uploader/providers/huaweicloud-scm/huaweicloud_scm.go
@@ -1,4 +1,4 @@
-﻿package huaweicloudscm
+package huaweicloudscm
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/huaweicloud-waf/huaweicloud_waf.go
+++ b/internal/pkg/core/uploader/providers/huaweicloud-waf/huaweicloud_waf.go
@@ -1,4 +1,4 @@
-﻿package huaweicloudwaf
+package huaweicloudwaf
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/jdcloud-ssl/jdcloud_ssl.go
+++ b/internal/pkg/core/uploader/providers/jdcloud-ssl/jdcloud_ssl.go
@@ -1,4 +1,4 @@
-﻿package jdcloudssl
+package jdcloudssl
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/jdcloud-ssl/jdcloud_ssl_test.go
+++ b/internal/pkg/core/uploader/providers/jdcloud-ssl/jdcloud_ssl_test.go
@@ -1,4 +1,4 @@
-﻿package jdcloudssl_test
+package jdcloudssl_test
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/qiniu-sslcert/qiniu_sslcert.go
+++ b/internal/pkg/core/uploader/providers/qiniu-sslcert/qiniu_sslcert.go
@@ -1,4 +1,4 @@
-﻿package qiniusslcert
+package qiniusslcert
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/tencentcloud-ssl/tencentcloud_ssl.go
+++ b/internal/pkg/core/uploader/providers/tencentcloud-ssl/tencentcloud_ssl.go
@@ -1,4 +1,4 @@
-﻿package tencentcloudssl
+package tencentcloudssl
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/ucloud-ussl/ucloud_ussl_test.go
+++ b/internal/pkg/core/uploader/providers/ucloud-ussl/ucloud_ussl_test.go
@@ -1,4 +1,4 @@
-﻿package ucloudussl_test
+package ucloudussl_test
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/upyun-ssl/upyun_ssl.go
+++ b/internal/pkg/core/uploader/providers/upyun-ssl/upyun_ssl.go
@@ -1,4 +1,4 @@
-﻿package upyunssl
+package upyunssl
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/upyun-ssl/upyun_ssl_test.go
+++ b/internal/pkg/core/uploader/providers/upyun-ssl/upyun_ssl_test.go
@@ -1,4 +1,4 @@
-﻿package upyunssl_test
+package upyunssl_test
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/providers/volcengine-certcenter/volcengine_certcenter_test.go
+++ b/internal/pkg/core/uploader/providers/volcengine-certcenter/volcengine_certcenter_test.go
@@ -1,4 +1,4 @@
-﻿package volcenginecertcenter_test
+package volcenginecertcenter_test
 
 import (
 	"context"

--- a/internal/pkg/core/uploader/uploader.go
+++ b/internal/pkg/core/uploader/uploader.go
@@ -1,4 +1,4 @@
-﻿package uploader
+package uploader
 
 import (
 	"context"

--- a/internal/pkg/logging/handler.go
+++ b/internal/pkg/logging/handler.go
@@ -1,4 +1,4 @@
-﻿package logging
+package logging
 
 import (
 	"context"

--- a/internal/pkg/logging/level.go
+++ b/internal/pkg/logging/level.go
@@ -1,4 +1,4 @@
-﻿package logging
+package logging
 
 import "log/slog"
 

--- a/internal/pkg/logging/record.go
+++ b/internal/pkg/logging/record.go
@@ -1,4 +1,4 @@
-﻿package logging
+package logging
 
 import (
 	"time"

--- a/internal/pkg/utils/certutil/common.go
+++ b/internal/pkg/utils/certutil/common.go
@@ -1,4 +1,4 @@
-﻿package certutil
+package certutil
 
 import (
 	"crypto/x509"

--- a/internal/pkg/utils/certutil/converter.go
+++ b/internal/pkg/utils/certutil/converter.go
@@ -1,4 +1,4 @@
-﻿package certutil
+package certutil
 
 import (
 	"crypto/ecdsa"

--- a/internal/pkg/utils/certutil/extractor.go
+++ b/internal/pkg/utils/certutil/extractor.go
@@ -1,4 +1,4 @@
-﻿package certutil
+package certutil
 
 import (
 	"encoding/pem"

--- a/internal/pkg/utils/certutil/parser.go
+++ b/internal/pkg/utils/certutil/parser.go
@@ -1,4 +1,4 @@
-﻿package certutil
+package certutil
 
 import (
 	"crypto"

--- a/internal/pkg/utils/certutil/transformer.go
+++ b/internal/pkg/utils/certutil/transformer.go
@@ -1,4 +1,4 @@
-﻿package certutil
+package certutil
 
 import (
 	"bytes"

--- a/internal/pkg/utils/fileutil/io.go
+++ b/internal/pkg/utils/fileutil/io.go
@@ -1,4 +1,4 @@
-﻿package fileutil
+package fileutil
 
 import (
 	"os"

--- a/internal/pkg/utils/maputil/getter.go
+++ b/internal/pkg/utils/maputil/getter.go
@@ -1,4 +1,4 @@
-﻿package maputil
+package maputil
 
 import (
 	"strconv"

--- a/internal/pkg/utils/maputil/marshal.go
+++ b/internal/pkg/utils/maputil/marshal.go
@@ -1,4 +1,4 @@
-﻿package maputil
+package maputil
 
 import (
 	mapstructure "github.com/go-viper/mapstructure/v2"

--- a/internal/pkg/utils/sliceutil/slices.go
+++ b/internal/pkg/utils/sliceutil/slices.go
@@ -1,4 +1,4 @@
-﻿package sliceutil
+package sliceutil
 
 // 创建给定切片一部分的浅拷贝，其包含通过所提供函数实现的测试的所有元素。
 //

--- a/internal/pkg/utils/typeutil/types.go
+++ b/internal/pkg/utils/typeutil/types.go
@@ -1,4 +1,4 @@
-﻿package typeutil
+package typeutil
 
 import "reflect"
 

--- a/internal/pkg/vendors/azure-sdk/common/config.go
+++ b/internal/pkg/vendors/azure-sdk/common/config.go
@@ -1,4 +1,4 @@
-﻿package common
+package common
 
 import (
 	"fmt"

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_body.go
@@ -5,29 +5,30 @@
 package model
 
 import (
-    "gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
+	"gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
 )
+
 type CreateRecordBodyTypeEnum string
 
 // List of Type
 const (
-    CreateRecordBodyTypeEnumA CreateRecordBodyTypeEnum = "A"
-    CreateRecordBodyTypeEnumAaaa CreateRecordBodyTypeEnum = "AAAA"
-    CreateRecordBodyTypeEnumCaa CreateRecordBodyTypeEnum = "CAA"
-    CreateRecordBodyTypeEnumCmauth CreateRecordBodyTypeEnum = "CMAUTH"
-    CreateRecordBodyTypeEnumCname CreateRecordBodyTypeEnum = "CNAME"
-    CreateRecordBodyTypeEnumMx CreateRecordBodyTypeEnum = "MX"
-    CreateRecordBodyTypeEnumNs CreateRecordBodyTypeEnum = "NS"
-    CreateRecordBodyTypeEnumPtr CreateRecordBodyTypeEnum = "PTR"
-    CreateRecordBodyTypeEnumRp CreateRecordBodyTypeEnum = "RP"
-    CreateRecordBodyTypeEnumSpf CreateRecordBodyTypeEnum = "SPF"
-    CreateRecordBodyTypeEnumSrv CreateRecordBodyTypeEnum = "SRV"
-    CreateRecordBodyTypeEnumTxt CreateRecordBodyTypeEnum = "TXT"
-    CreateRecordBodyTypeEnumUrl CreateRecordBodyTypeEnum = "URL"
+	CreateRecordBodyTypeEnumA      CreateRecordBodyTypeEnum = "A"
+	CreateRecordBodyTypeEnumAaaa   CreateRecordBodyTypeEnum = "AAAA"
+	CreateRecordBodyTypeEnumCaa    CreateRecordBodyTypeEnum = "CAA"
+	CreateRecordBodyTypeEnumCmauth CreateRecordBodyTypeEnum = "CMAUTH"
+	CreateRecordBodyTypeEnumCname  CreateRecordBodyTypeEnum = "CNAME"
+	CreateRecordBodyTypeEnumMx     CreateRecordBodyTypeEnum = "MX"
+	CreateRecordBodyTypeEnumNs     CreateRecordBodyTypeEnum = "NS"
+	CreateRecordBodyTypeEnumPtr    CreateRecordBodyTypeEnum = "PTR"
+	CreateRecordBodyTypeEnumRp     CreateRecordBodyTypeEnum = "RP"
+	CreateRecordBodyTypeEnumSpf    CreateRecordBodyTypeEnum = "SPF"
+	CreateRecordBodyTypeEnumSrv    CreateRecordBodyTypeEnum = "SRV"
+	CreateRecordBodyTypeEnumTxt    CreateRecordBodyTypeEnum = "TXT"
+	CreateRecordBodyTypeEnumUrl    CreateRecordBodyTypeEnum = "URL"
 )
 
 type CreateRecordBody struct {
-    position.Body
+	position.Body
 	// 主机头
 	Rr string `json:"rr"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_openapi_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_openapi_body.go
@@ -5,26 +5,27 @@
 package model
 
 import (
-    "gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
+	"gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
 )
+
 type CreateRecordOpenapiBodyTypeEnum string
 
 // List of Type
 const (
-    CreateRecordOpenapiBodyTypeEnumA CreateRecordOpenapiBodyTypeEnum = "A"
-    CreateRecordOpenapiBodyTypeEnumAaaa CreateRecordOpenapiBodyTypeEnum = "AAAA"
-    CreateRecordOpenapiBodyTypeEnumCname CreateRecordOpenapiBodyTypeEnum = "CNAME"
-    CreateRecordOpenapiBodyTypeEnumMx CreateRecordOpenapiBodyTypeEnum = "MX"
-    CreateRecordOpenapiBodyTypeEnumTxt CreateRecordOpenapiBodyTypeEnum = "TXT"
-    CreateRecordOpenapiBodyTypeEnumNs CreateRecordOpenapiBodyTypeEnum = "NS"
-    CreateRecordOpenapiBodyTypeEnumSpf CreateRecordOpenapiBodyTypeEnum = "SPF"
-    CreateRecordOpenapiBodyTypeEnumSrv CreateRecordOpenapiBodyTypeEnum = "SRV"
-    CreateRecordOpenapiBodyTypeEnumCaa CreateRecordOpenapiBodyTypeEnum = "CAA"
-    CreateRecordOpenapiBodyTypeEnumCmauth CreateRecordOpenapiBodyTypeEnum = "CMAUTH"
+	CreateRecordOpenapiBodyTypeEnumA      CreateRecordOpenapiBodyTypeEnum = "A"
+	CreateRecordOpenapiBodyTypeEnumAaaa   CreateRecordOpenapiBodyTypeEnum = "AAAA"
+	CreateRecordOpenapiBodyTypeEnumCname  CreateRecordOpenapiBodyTypeEnum = "CNAME"
+	CreateRecordOpenapiBodyTypeEnumMx     CreateRecordOpenapiBodyTypeEnum = "MX"
+	CreateRecordOpenapiBodyTypeEnumTxt    CreateRecordOpenapiBodyTypeEnum = "TXT"
+	CreateRecordOpenapiBodyTypeEnumNs     CreateRecordOpenapiBodyTypeEnum = "NS"
+	CreateRecordOpenapiBodyTypeEnumSpf    CreateRecordOpenapiBodyTypeEnum = "SPF"
+	CreateRecordOpenapiBodyTypeEnumSrv    CreateRecordOpenapiBodyTypeEnum = "SRV"
+	CreateRecordOpenapiBodyTypeEnumCaa    CreateRecordOpenapiBodyTypeEnum = "CAA"
+	CreateRecordOpenapiBodyTypeEnumCmauth CreateRecordOpenapiBodyTypeEnum = "CMAUTH"
 )
 
 type CreateRecordOpenapiBody struct {
-    position.Body
+	position.Body
 	// 主机头
 	Rr string `json:"rr"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_openapi_request.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_openapi_request.go
@@ -4,9 +4,6 @@
 
 package model
 
-
-
 type CreateRecordOpenapiRequest struct {
-
 	CreateRecordOpenapiBody *CreateRecordOpenapiBody `json:"createRecordOpenapiBody,omitempty"`
 }

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_openapi_response.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_openapi_response.go
@@ -4,19 +4,17 @@
 
 package model
 
-
 type CreateRecordOpenapiResponseStateEnum string
 
 // List of State
 const (
-    CreateRecordOpenapiResponseStateEnumError CreateRecordOpenapiResponseStateEnum = "ERROR"
-    CreateRecordOpenapiResponseStateEnumException CreateRecordOpenapiResponseStateEnum = "EXCEPTION"
-    CreateRecordOpenapiResponseStateEnumForbidden CreateRecordOpenapiResponseStateEnum = "FORBIDDEN"
-    CreateRecordOpenapiResponseStateEnumOk CreateRecordOpenapiResponseStateEnum = "OK"
+	CreateRecordOpenapiResponseStateEnumError     CreateRecordOpenapiResponseStateEnum = "ERROR"
+	CreateRecordOpenapiResponseStateEnumException CreateRecordOpenapiResponseStateEnum = "EXCEPTION"
+	CreateRecordOpenapiResponseStateEnumForbidden CreateRecordOpenapiResponseStateEnum = "FORBIDDEN"
+	CreateRecordOpenapiResponseStateEnumOk        CreateRecordOpenapiResponseStateEnum = "OK"
 )
 
 type CreateRecordOpenapiResponse struct {
-
 	RequestId string `json:"requestId,omitempty"`
 
 	ErrorMessage string `json:"errorMessage,omitempty"`

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_openapi_response_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_openapi_response_body.go
@@ -4,32 +4,31 @@
 
 package model
 
-
 type CreateRecordOpenapiResponseBodyTypeEnum string
 
 // List of Type
 const (
-    CreateRecordOpenapiResponseBodyTypeEnumA CreateRecordOpenapiResponseBodyTypeEnum = "A"
-    CreateRecordOpenapiResponseBodyTypeEnumAaaa CreateRecordOpenapiResponseBodyTypeEnum = "AAAA"
-    CreateRecordOpenapiResponseBodyTypeEnumCname CreateRecordOpenapiResponseBodyTypeEnum = "CNAME"
-    CreateRecordOpenapiResponseBodyTypeEnumMx CreateRecordOpenapiResponseBodyTypeEnum = "MX"
-    CreateRecordOpenapiResponseBodyTypeEnumTxt CreateRecordOpenapiResponseBodyTypeEnum = "TXT"
-    CreateRecordOpenapiResponseBodyTypeEnumNs CreateRecordOpenapiResponseBodyTypeEnum = "NS"
-    CreateRecordOpenapiResponseBodyTypeEnumSpf CreateRecordOpenapiResponseBodyTypeEnum = "SPF"
-    CreateRecordOpenapiResponseBodyTypeEnumSrv CreateRecordOpenapiResponseBodyTypeEnum = "SRV"
-    CreateRecordOpenapiResponseBodyTypeEnumCaa CreateRecordOpenapiResponseBodyTypeEnum = "CAA"
-    CreateRecordOpenapiResponseBodyTypeEnumCmauth CreateRecordOpenapiResponseBodyTypeEnum = "CMAUTH"
+	CreateRecordOpenapiResponseBodyTypeEnumA      CreateRecordOpenapiResponseBodyTypeEnum = "A"
+	CreateRecordOpenapiResponseBodyTypeEnumAaaa   CreateRecordOpenapiResponseBodyTypeEnum = "AAAA"
+	CreateRecordOpenapiResponseBodyTypeEnumCname  CreateRecordOpenapiResponseBodyTypeEnum = "CNAME"
+	CreateRecordOpenapiResponseBodyTypeEnumMx     CreateRecordOpenapiResponseBodyTypeEnum = "MX"
+	CreateRecordOpenapiResponseBodyTypeEnumTxt    CreateRecordOpenapiResponseBodyTypeEnum = "TXT"
+	CreateRecordOpenapiResponseBodyTypeEnumNs     CreateRecordOpenapiResponseBodyTypeEnum = "NS"
+	CreateRecordOpenapiResponseBodyTypeEnumSpf    CreateRecordOpenapiResponseBodyTypeEnum = "SPF"
+	CreateRecordOpenapiResponseBodyTypeEnumSrv    CreateRecordOpenapiResponseBodyTypeEnum = "SRV"
+	CreateRecordOpenapiResponseBodyTypeEnumCaa    CreateRecordOpenapiResponseBodyTypeEnum = "CAA"
+	CreateRecordOpenapiResponseBodyTypeEnumCmauth CreateRecordOpenapiResponseBodyTypeEnum = "CMAUTH"
 )
+
 type CreateRecordOpenapiResponseBodyStateEnum string
 
 // List of State
 const (
-    CreateRecordOpenapiResponseBodyStateEnumDisabled CreateRecordOpenapiResponseBodyStateEnum = "DISABLED"
-    CreateRecordOpenapiResponseBodyStateEnumEnabled CreateRecordOpenapiResponseBodyStateEnum = "ENABLED"
+	CreateRecordOpenapiResponseBodyStateEnumDisabled CreateRecordOpenapiResponseBodyStateEnum = "DISABLED"
+	CreateRecordOpenapiResponseBodyStateEnumEnabled  CreateRecordOpenapiResponseBodyStateEnum = "ENABLED"
 )
 
 type CreateRecordOpenapiResponseBody struct {
-
 	// 主机头
 	Rr string `json:"rr,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_openapi_response_tags.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_openapi_response_tags.go
@@ -4,10 +4,7 @@
 
 package model
 
-
-
 type CreateRecordOpenapiResponseTags struct {
-
 	// 标签ID
 	TagId string `json:"tagId,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_request.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_request.go
@@ -4,9 +4,6 @@
 
 package model
 
-
-
 type CreateRecordRequest struct {
-
 	CreateRecordBody *CreateRecordBody `json:"createRecordBody,omitempty"`
 }

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_response.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_response.go
@@ -4,19 +4,17 @@
 
 package model
 
-
 type CreateRecordResponseStateEnum string
 
 // List of State
 const (
-    CreateRecordResponseStateEnumError CreateRecordResponseStateEnum = "ERROR"
-    CreateRecordResponseStateEnumException CreateRecordResponseStateEnum = "EXCEPTION"
-    CreateRecordResponseStateEnumForbidden CreateRecordResponseStateEnum = "FORBIDDEN"
-    CreateRecordResponseStateEnumOk CreateRecordResponseStateEnum = "OK"
+	CreateRecordResponseStateEnumError     CreateRecordResponseStateEnum = "ERROR"
+	CreateRecordResponseStateEnumException CreateRecordResponseStateEnum = "EXCEPTION"
+	CreateRecordResponseStateEnumForbidden CreateRecordResponseStateEnum = "FORBIDDEN"
+	CreateRecordResponseStateEnumOk        CreateRecordResponseStateEnum = "OK"
 )
 
 type CreateRecordResponse struct {
-
 	RequestId string `json:"requestId,omitempty"`
 
 	ErrorMessage string `json:"errorMessage,omitempty"`

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_response_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_response_body.go
@@ -4,43 +4,43 @@
 
 package model
 
-
 type CreateRecordResponseBodyTypeEnum string
 
 // List of Type
 const (
-    CreateRecordResponseBodyTypeEnumA CreateRecordResponseBodyTypeEnum = "A"
-    CreateRecordResponseBodyTypeEnumAaaa CreateRecordResponseBodyTypeEnum = "AAAA"
-    CreateRecordResponseBodyTypeEnumCaa CreateRecordResponseBodyTypeEnum = "CAA"
-    CreateRecordResponseBodyTypeEnumCmauth CreateRecordResponseBodyTypeEnum = "CMAUTH"
-    CreateRecordResponseBodyTypeEnumCname CreateRecordResponseBodyTypeEnum = "CNAME"
-    CreateRecordResponseBodyTypeEnumMx CreateRecordResponseBodyTypeEnum = "MX"
-    CreateRecordResponseBodyTypeEnumNs CreateRecordResponseBodyTypeEnum = "NS"
-    CreateRecordResponseBodyTypeEnumPtr CreateRecordResponseBodyTypeEnum = "PTR"
-    CreateRecordResponseBodyTypeEnumRp CreateRecordResponseBodyTypeEnum = "RP"
-    CreateRecordResponseBodyTypeEnumSpf CreateRecordResponseBodyTypeEnum = "SPF"
-    CreateRecordResponseBodyTypeEnumSrv CreateRecordResponseBodyTypeEnum = "SRV"
-    CreateRecordResponseBodyTypeEnumTxt CreateRecordResponseBodyTypeEnum = "TXT"
-    CreateRecordResponseBodyTypeEnumUrl CreateRecordResponseBodyTypeEnum = "URL"
+	CreateRecordResponseBodyTypeEnumA      CreateRecordResponseBodyTypeEnum = "A"
+	CreateRecordResponseBodyTypeEnumAaaa   CreateRecordResponseBodyTypeEnum = "AAAA"
+	CreateRecordResponseBodyTypeEnumCaa    CreateRecordResponseBodyTypeEnum = "CAA"
+	CreateRecordResponseBodyTypeEnumCmauth CreateRecordResponseBodyTypeEnum = "CMAUTH"
+	CreateRecordResponseBodyTypeEnumCname  CreateRecordResponseBodyTypeEnum = "CNAME"
+	CreateRecordResponseBodyTypeEnumMx     CreateRecordResponseBodyTypeEnum = "MX"
+	CreateRecordResponseBodyTypeEnumNs     CreateRecordResponseBodyTypeEnum = "NS"
+	CreateRecordResponseBodyTypeEnumPtr    CreateRecordResponseBodyTypeEnum = "PTR"
+	CreateRecordResponseBodyTypeEnumRp     CreateRecordResponseBodyTypeEnum = "RP"
+	CreateRecordResponseBodyTypeEnumSpf    CreateRecordResponseBodyTypeEnum = "SPF"
+	CreateRecordResponseBodyTypeEnumSrv    CreateRecordResponseBodyTypeEnum = "SRV"
+	CreateRecordResponseBodyTypeEnumTxt    CreateRecordResponseBodyTypeEnum = "TXT"
+	CreateRecordResponseBodyTypeEnumUrl    CreateRecordResponseBodyTypeEnum = "URL"
 )
+
 type CreateRecordResponseBodyTimedStatusEnum string
 
 // List of TimedStatus
 const (
-    CreateRecordResponseBodyTimedStatusEnumDisabled CreateRecordResponseBodyTimedStatusEnum = "DISABLED"
-    CreateRecordResponseBodyTimedStatusEnumEnabled CreateRecordResponseBodyTimedStatusEnum = "ENABLED"
-    CreateRecordResponseBodyTimedStatusEnumTimed CreateRecordResponseBodyTimedStatusEnum = "TIMED"
+	CreateRecordResponseBodyTimedStatusEnumDisabled CreateRecordResponseBodyTimedStatusEnum = "DISABLED"
+	CreateRecordResponseBodyTimedStatusEnumEnabled  CreateRecordResponseBodyTimedStatusEnum = "ENABLED"
+	CreateRecordResponseBodyTimedStatusEnumTimed    CreateRecordResponseBodyTimedStatusEnum = "TIMED"
 )
+
 type CreateRecordResponseBodyStateEnum string
 
 // List of State
 const (
-    CreateRecordResponseBodyStateEnumDisabled CreateRecordResponseBodyStateEnum = "DISABLED"
-    CreateRecordResponseBodyStateEnumEnabled CreateRecordResponseBodyStateEnum = "ENABLED"
+	CreateRecordResponseBodyStateEnumDisabled CreateRecordResponseBodyStateEnum = "DISABLED"
+	CreateRecordResponseBodyStateEnumEnabled  CreateRecordResponseBodyStateEnum = "ENABLED"
 )
 
 type CreateRecordResponseBody struct {
-
 	// 主机头
 	Rr string `json:"rr,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_response_tags.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/create_record_response_tags.go
@@ -4,10 +4,7 @@
 
 package model
 
-
-
 type CreateRecordResponseTags struct {
-
 	// 标签ID
 	TagId string `json:"tagId,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_body.go
@@ -5,11 +5,11 @@
 package model
 
 import (
-    "gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
+	"gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
 )
 
 type DeleteRecordBody struct {
-    position.Body
+	position.Body
 	// 解析记录ID列表
 	RecordIdList []string `json:"recordIdList"`
 }

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_openapi_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_openapi_body.go
@@ -5,11 +5,11 @@
 package model
 
 import (
-    "gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
+	"gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
 )
 
 type DeleteRecordOpenapiBody struct {
-    position.Body
+	position.Body
 	// 待删除的解析记录ID请求体
 	RecordIdList []string `json:"recordIdList"`
 }

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_openapi_request.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_openapi_request.go
@@ -4,9 +4,6 @@
 
 package model
 
-
-
 type DeleteRecordOpenapiRequest struct {
-
 	DeleteRecordOpenapiBody *DeleteRecordOpenapiBody `json:"deleteRecordOpenapiBody,omitempty"`
 }

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_openapi_response.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_openapi_response.go
@@ -4,19 +4,17 @@
 
 package model
 
-
 type DeleteRecordOpenapiResponseStateEnum string
 
 // List of State
 const (
-    DeleteRecordOpenapiResponseStateEnumError DeleteRecordOpenapiResponseStateEnum = "ERROR"
-    DeleteRecordOpenapiResponseStateEnumException DeleteRecordOpenapiResponseStateEnum = "EXCEPTION"
-    DeleteRecordOpenapiResponseStateEnumForbidden DeleteRecordOpenapiResponseStateEnum = "FORBIDDEN"
-    DeleteRecordOpenapiResponseStateEnumOk DeleteRecordOpenapiResponseStateEnum = "OK"
+	DeleteRecordOpenapiResponseStateEnumError     DeleteRecordOpenapiResponseStateEnum = "ERROR"
+	DeleteRecordOpenapiResponseStateEnumException DeleteRecordOpenapiResponseStateEnum = "EXCEPTION"
+	DeleteRecordOpenapiResponseStateEnumForbidden DeleteRecordOpenapiResponseStateEnum = "FORBIDDEN"
+	DeleteRecordOpenapiResponseStateEnumOk        DeleteRecordOpenapiResponseStateEnum = "OK"
 )
 
 type DeleteRecordOpenapiResponse struct {
-
 	RequestId string `json:"requestId,omitempty"`
 
 	ErrorMessage string `json:"errorMessage,omitempty"`

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_openapi_response_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_openapi_response_body.go
@@ -4,17 +4,15 @@
 
 package model
 
-
 type DeleteRecordOpenapiResponseBodyCodeEnum string
 
 // List of Code
 const (
-    DeleteRecordOpenapiResponseBodyCodeEnumError DeleteRecordOpenapiResponseBodyCodeEnum = "ERROR"
-    DeleteRecordOpenapiResponseBodyCodeEnumSuccess DeleteRecordOpenapiResponseBodyCodeEnum = "SUCCESS"
+	DeleteRecordOpenapiResponseBodyCodeEnumError   DeleteRecordOpenapiResponseBodyCodeEnum = "ERROR"
+	DeleteRecordOpenapiResponseBodyCodeEnumSuccess DeleteRecordOpenapiResponseBodyCodeEnum = "SUCCESS"
 )
 
 type DeleteRecordOpenapiResponseBody struct {
-
 	// 结果说明
 	Msg string `json:"msg,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_request.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_request.go
@@ -4,9 +4,6 @@
 
 package model
 
-
-
 type DeleteRecordRequest struct {
-
 	DeleteRecordBody *DeleteRecordBody `json:"deleteRecordBody,omitempty"`
 }

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_response.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_response.go
@@ -4,19 +4,17 @@
 
 package model
 
-
 type DeleteRecordResponseStateEnum string
 
 // List of State
 const (
-    DeleteRecordResponseStateEnumError DeleteRecordResponseStateEnum = "ERROR"
-    DeleteRecordResponseStateEnumException DeleteRecordResponseStateEnum = "EXCEPTION"
-    DeleteRecordResponseStateEnumForbidden DeleteRecordResponseStateEnum = "FORBIDDEN"
-    DeleteRecordResponseStateEnumOk DeleteRecordResponseStateEnum = "OK"
+	DeleteRecordResponseStateEnumError     DeleteRecordResponseStateEnum = "ERROR"
+	DeleteRecordResponseStateEnumException DeleteRecordResponseStateEnum = "EXCEPTION"
+	DeleteRecordResponseStateEnumForbidden DeleteRecordResponseStateEnum = "FORBIDDEN"
+	DeleteRecordResponseStateEnumOk        DeleteRecordResponseStateEnum = "OK"
 )
 
 type DeleteRecordResponse struct {
-
 	RequestId string `json:"requestId,omitempty"`
 
 	ErrorMessage string `json:"errorMessage,omitempty"`

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_response_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/delete_record_response_body.go
@@ -4,17 +4,15 @@
 
 package model
 
-
 type DeleteRecordResponseBodyCodeEnum string
 
 // List of Code
 const (
-    DeleteRecordResponseBodyCodeEnumError DeleteRecordResponseBodyCodeEnum = "ERROR"
-    DeleteRecordResponseBodyCodeEnumSuccess DeleteRecordResponseBodyCodeEnum = "SUCCESS"
+	DeleteRecordResponseBodyCodeEnumError   DeleteRecordResponseBodyCodeEnum = "ERROR"
+	DeleteRecordResponseBodyCodeEnumSuccess DeleteRecordResponseBodyCodeEnum = "SUCCESS"
 )
 
 type DeleteRecordResponseBody struct {
-
 	// 结果说明
 	Msg string `json:"msg,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_body.go
@@ -5,11 +5,11 @@
 package model
 
 import (
-    "gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
+	"gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
 )
 
 type ListRecordBody struct {
-    position.Body
+	position.Body
 	// 域名
 	DomainName string `json:"domainName"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_body.go
@@ -5,11 +5,11 @@
 package model
 
 import (
-    "gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
+	"gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
 )
 
 type ListRecordOpenapiBody struct {
-    position.Body
+	position.Body
 	// 域名
 	DomainName string `json:"domainName"`
 }

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_query.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_query.go
@@ -5,11 +5,11 @@
 package model
 
 import (
-    "gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
+	"gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
 )
 
 type ListRecordOpenapiQuery struct {
-    position.Query
+	position.Query
 	// 页大小
 	PageSize *int32 `json:"pageSize,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_request.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_request.go
@@ -4,10 +4,7 @@
 
 package model
 
-
-
 type ListRecordOpenapiRequest struct {
-
 	ListRecordOpenapiQuery *ListRecordOpenapiQuery `json:"listRecordOpenapiQuery,omitempty"`
 
 	ListRecordOpenapiBody *ListRecordOpenapiBody `json:"listRecordOpenapiBody,omitempty"`

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_response.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_response.go
@@ -4,19 +4,17 @@
 
 package model
 
-
 type ListRecordOpenapiResponseStateEnum string
 
 // List of State
 const (
-    ListRecordOpenapiResponseStateEnumError ListRecordOpenapiResponseStateEnum = "ERROR"
-    ListRecordOpenapiResponseStateEnumException ListRecordOpenapiResponseStateEnum = "EXCEPTION"
-    ListRecordOpenapiResponseStateEnumForbidden ListRecordOpenapiResponseStateEnum = "FORBIDDEN"
-    ListRecordOpenapiResponseStateEnumOk ListRecordOpenapiResponseStateEnum = "OK"
+	ListRecordOpenapiResponseStateEnumError     ListRecordOpenapiResponseStateEnum = "ERROR"
+	ListRecordOpenapiResponseStateEnumException ListRecordOpenapiResponseStateEnum = "EXCEPTION"
+	ListRecordOpenapiResponseStateEnumForbidden ListRecordOpenapiResponseStateEnum = "FORBIDDEN"
+	ListRecordOpenapiResponseStateEnumOk        ListRecordOpenapiResponseStateEnum = "OK"
 )
 
 type ListRecordOpenapiResponse struct {
-
 	RequestId string `json:"requestId,omitempty"`
 
 	ErrorMessage string `json:"errorMessage,omitempty"`

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_response_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_response_body.go
@@ -4,10 +4,7 @@
 
 package model
 
-
-
 type ListRecordOpenapiResponseBody struct {
-
 	// 当前页的具体数据列表
 	Data *[]ListRecordOpenapiResponseData `json:"data,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_response_data.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_response_data.go
@@ -4,40 +4,40 @@
 
 package model
 
-
 type ListRecordOpenapiResponseDataTypeEnum string
 
 // List of Type
 const (
-    ListRecordOpenapiResponseDataTypeEnumA ListRecordOpenapiResponseDataTypeEnum = "A"
-    ListRecordOpenapiResponseDataTypeEnumAaaa ListRecordOpenapiResponseDataTypeEnum = "AAAA"
-    ListRecordOpenapiResponseDataTypeEnumCname ListRecordOpenapiResponseDataTypeEnum = "CNAME"
-    ListRecordOpenapiResponseDataTypeEnumMx ListRecordOpenapiResponseDataTypeEnum = "MX"
-    ListRecordOpenapiResponseDataTypeEnumTxt ListRecordOpenapiResponseDataTypeEnum = "TXT"
-    ListRecordOpenapiResponseDataTypeEnumNs ListRecordOpenapiResponseDataTypeEnum = "NS"
-    ListRecordOpenapiResponseDataTypeEnumSpf ListRecordOpenapiResponseDataTypeEnum = "SPF"
-    ListRecordOpenapiResponseDataTypeEnumSrv ListRecordOpenapiResponseDataTypeEnum = "SRV"
-    ListRecordOpenapiResponseDataTypeEnumCaa ListRecordOpenapiResponseDataTypeEnum = "CAA"
-    ListRecordOpenapiResponseDataTypeEnumCmauth ListRecordOpenapiResponseDataTypeEnum = "CMAUTH"
+	ListRecordOpenapiResponseDataTypeEnumA      ListRecordOpenapiResponseDataTypeEnum = "A"
+	ListRecordOpenapiResponseDataTypeEnumAaaa   ListRecordOpenapiResponseDataTypeEnum = "AAAA"
+	ListRecordOpenapiResponseDataTypeEnumCname  ListRecordOpenapiResponseDataTypeEnum = "CNAME"
+	ListRecordOpenapiResponseDataTypeEnumMx     ListRecordOpenapiResponseDataTypeEnum = "MX"
+	ListRecordOpenapiResponseDataTypeEnumTxt    ListRecordOpenapiResponseDataTypeEnum = "TXT"
+	ListRecordOpenapiResponseDataTypeEnumNs     ListRecordOpenapiResponseDataTypeEnum = "NS"
+	ListRecordOpenapiResponseDataTypeEnumSpf    ListRecordOpenapiResponseDataTypeEnum = "SPF"
+	ListRecordOpenapiResponseDataTypeEnumSrv    ListRecordOpenapiResponseDataTypeEnum = "SRV"
+	ListRecordOpenapiResponseDataTypeEnumCaa    ListRecordOpenapiResponseDataTypeEnum = "CAA"
+	ListRecordOpenapiResponseDataTypeEnumCmauth ListRecordOpenapiResponseDataTypeEnum = "CMAUTH"
 )
+
 type ListRecordOpenapiResponseDataTimedStatusEnum string
 
 // List of TimedStatus
 const (
-    ListRecordOpenapiResponseDataTimedStatusEnumDisabled ListRecordOpenapiResponseDataTimedStatusEnum = "DISABLED"
-    ListRecordOpenapiResponseDataTimedStatusEnumEnabled ListRecordOpenapiResponseDataTimedStatusEnum = "ENABLED"
-    ListRecordOpenapiResponseDataTimedStatusEnumTimed ListRecordOpenapiResponseDataTimedStatusEnum = "TIMED"
+	ListRecordOpenapiResponseDataTimedStatusEnumDisabled ListRecordOpenapiResponseDataTimedStatusEnum = "DISABLED"
+	ListRecordOpenapiResponseDataTimedStatusEnumEnabled  ListRecordOpenapiResponseDataTimedStatusEnum = "ENABLED"
+	ListRecordOpenapiResponseDataTimedStatusEnumTimed    ListRecordOpenapiResponseDataTimedStatusEnum = "TIMED"
 )
+
 type ListRecordOpenapiResponseDataStateEnum string
 
 // List of State
 const (
-    ListRecordOpenapiResponseDataStateEnumDisabled ListRecordOpenapiResponseDataStateEnum = "DISABLED"
-    ListRecordOpenapiResponseDataStateEnumEnabled ListRecordOpenapiResponseDataStateEnum = "ENABLED"
+	ListRecordOpenapiResponseDataStateEnumDisabled ListRecordOpenapiResponseDataStateEnum = "DISABLED"
+	ListRecordOpenapiResponseDataStateEnumEnabled  ListRecordOpenapiResponseDataStateEnum = "ENABLED"
 )
 
 type ListRecordOpenapiResponseData struct {
-
 	// 主机头
 	Rr string `json:"rr,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_response_tags.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_openapi_response_tags.go
@@ -4,10 +4,7 @@
 
 package model
 
-
-
 type ListRecordOpenapiResponseTags struct {
-
 	// 标签ID
 	TagId string `json:"tagId,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_query.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_query.go
@@ -5,11 +5,11 @@
 package model
 
 import (
-    "gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
+	"gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
 )
 
 type ListRecordQuery struct {
-    position.Query
+	position.Query
 	// 页大小
 	PageSize *int32 `json:"pageSize,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_request.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_request.go
@@ -4,10 +4,7 @@
 
 package model
 
-
-
 type ListRecordRequest struct {
-
 	ListRecordBody *ListRecordBody `json:"listRecordBody,omitempty"`
 
 	ListRecordQuery *ListRecordQuery `json:"listRecordQuery,omitempty"`

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_response.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_response.go
@@ -4,19 +4,17 @@
 
 package model
 
-
 type ListRecordResponseStateEnum string
 
 // List of State
 const (
-    ListRecordResponseStateEnumError ListRecordResponseStateEnum = "ERROR"
-    ListRecordResponseStateEnumException ListRecordResponseStateEnum = "EXCEPTION"
-    ListRecordResponseStateEnumForbidden ListRecordResponseStateEnum = "FORBIDDEN"
-    ListRecordResponseStateEnumOk ListRecordResponseStateEnum = "OK"
+	ListRecordResponseStateEnumError     ListRecordResponseStateEnum = "ERROR"
+	ListRecordResponseStateEnumException ListRecordResponseStateEnum = "EXCEPTION"
+	ListRecordResponseStateEnumForbidden ListRecordResponseStateEnum = "FORBIDDEN"
+	ListRecordResponseStateEnumOk        ListRecordResponseStateEnum = "OK"
 )
 
 type ListRecordResponse struct {
-
 	RequestId string `json:"requestId,omitempty"`
 
 	ErrorMessage string `json:"errorMessage,omitempty"`

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_response_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_response_body.go
@@ -4,10 +4,7 @@
 
 package model
 
-
-
 type ListRecordResponseBody struct {
-
 	// 总页数
 	TotalPages *int32 `json:"totalPages,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_response_results.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/list_record_response_results.go
@@ -4,43 +4,43 @@
 
 package model
 
-
 type ListRecordResponseResultsTypeEnum string
 
 // List of Type
 const (
-    ListRecordResponseResultsTypeEnumA ListRecordResponseResultsTypeEnum = "A"
-    ListRecordResponseResultsTypeEnumAaaa ListRecordResponseResultsTypeEnum = "AAAA"
-    ListRecordResponseResultsTypeEnumCaa ListRecordResponseResultsTypeEnum = "CAA"
-    ListRecordResponseResultsTypeEnumCmauth ListRecordResponseResultsTypeEnum = "CMAUTH"
-    ListRecordResponseResultsTypeEnumCname ListRecordResponseResultsTypeEnum = "CNAME"
-    ListRecordResponseResultsTypeEnumMx ListRecordResponseResultsTypeEnum = "MX"
-    ListRecordResponseResultsTypeEnumNs ListRecordResponseResultsTypeEnum = "NS"
-    ListRecordResponseResultsTypeEnumPtr ListRecordResponseResultsTypeEnum = "PTR"
-    ListRecordResponseResultsTypeEnumRp ListRecordResponseResultsTypeEnum = "RP"
-    ListRecordResponseResultsTypeEnumSpf ListRecordResponseResultsTypeEnum = "SPF"
-    ListRecordResponseResultsTypeEnumSrv ListRecordResponseResultsTypeEnum = "SRV"
-    ListRecordResponseResultsTypeEnumTxt ListRecordResponseResultsTypeEnum = "TXT"
-    ListRecordResponseResultsTypeEnumUrl ListRecordResponseResultsTypeEnum = "URL"
+	ListRecordResponseResultsTypeEnumA      ListRecordResponseResultsTypeEnum = "A"
+	ListRecordResponseResultsTypeEnumAaaa   ListRecordResponseResultsTypeEnum = "AAAA"
+	ListRecordResponseResultsTypeEnumCaa    ListRecordResponseResultsTypeEnum = "CAA"
+	ListRecordResponseResultsTypeEnumCmauth ListRecordResponseResultsTypeEnum = "CMAUTH"
+	ListRecordResponseResultsTypeEnumCname  ListRecordResponseResultsTypeEnum = "CNAME"
+	ListRecordResponseResultsTypeEnumMx     ListRecordResponseResultsTypeEnum = "MX"
+	ListRecordResponseResultsTypeEnumNs     ListRecordResponseResultsTypeEnum = "NS"
+	ListRecordResponseResultsTypeEnumPtr    ListRecordResponseResultsTypeEnum = "PTR"
+	ListRecordResponseResultsTypeEnumRp     ListRecordResponseResultsTypeEnum = "RP"
+	ListRecordResponseResultsTypeEnumSpf    ListRecordResponseResultsTypeEnum = "SPF"
+	ListRecordResponseResultsTypeEnumSrv    ListRecordResponseResultsTypeEnum = "SRV"
+	ListRecordResponseResultsTypeEnumTxt    ListRecordResponseResultsTypeEnum = "TXT"
+	ListRecordResponseResultsTypeEnumUrl    ListRecordResponseResultsTypeEnum = "URL"
 )
+
 type ListRecordResponseResultsTimedStatusEnum string
 
 // List of TimedStatus
 const (
-    ListRecordResponseResultsTimedStatusEnumDisabled ListRecordResponseResultsTimedStatusEnum = "DISABLED"
-    ListRecordResponseResultsTimedStatusEnumEnabled ListRecordResponseResultsTimedStatusEnum = "ENABLED"
-    ListRecordResponseResultsTimedStatusEnumTimed ListRecordResponseResultsTimedStatusEnum = "TIMED"
+	ListRecordResponseResultsTimedStatusEnumDisabled ListRecordResponseResultsTimedStatusEnum = "DISABLED"
+	ListRecordResponseResultsTimedStatusEnumEnabled  ListRecordResponseResultsTimedStatusEnum = "ENABLED"
+	ListRecordResponseResultsTimedStatusEnumTimed    ListRecordResponseResultsTimedStatusEnum = "TIMED"
 )
+
 type ListRecordResponseResultsStateEnum string
 
 // List of State
 const (
-    ListRecordResponseResultsStateEnumDisabled ListRecordResponseResultsStateEnum = "DISABLED"
-    ListRecordResponseResultsStateEnumEnabled ListRecordResponseResultsStateEnum = "ENABLED"
+	ListRecordResponseResultsStateEnumDisabled ListRecordResponseResultsStateEnum = "DISABLED"
+	ListRecordResponseResultsStateEnumEnabled  ListRecordResponseResultsStateEnum = "ENABLED"
 )
 
 type ListRecordResponseResults struct {
-
 	// 主机头
 	Rr string `json:"rr,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_body.go
@@ -5,29 +5,30 @@
 package model
 
 import (
-    "gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
+	"gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
 )
+
 type ModifyRecordBodyTypeEnum string
 
 // List of Type
 const (
-    ModifyRecordBodyTypeEnumA ModifyRecordBodyTypeEnum = "A"
-    ModifyRecordBodyTypeEnumAaaa ModifyRecordBodyTypeEnum = "AAAA"
-    ModifyRecordBodyTypeEnumCaa ModifyRecordBodyTypeEnum = "CAA"
-    ModifyRecordBodyTypeEnumCmauth ModifyRecordBodyTypeEnum = "CMAUTH"
-    ModifyRecordBodyTypeEnumCname ModifyRecordBodyTypeEnum = "CNAME"
-    ModifyRecordBodyTypeEnumMx ModifyRecordBodyTypeEnum = "MX"
-    ModifyRecordBodyTypeEnumNs ModifyRecordBodyTypeEnum = "NS"
-    ModifyRecordBodyTypeEnumPtr ModifyRecordBodyTypeEnum = "PTR"
-    ModifyRecordBodyTypeEnumRp ModifyRecordBodyTypeEnum = "RP"
-    ModifyRecordBodyTypeEnumSpf ModifyRecordBodyTypeEnum = "SPF"
-    ModifyRecordBodyTypeEnumSrv ModifyRecordBodyTypeEnum = "SRV"
-    ModifyRecordBodyTypeEnumTxt ModifyRecordBodyTypeEnum = "TXT"
-    ModifyRecordBodyTypeEnumUrl ModifyRecordBodyTypeEnum = "URL"
+	ModifyRecordBodyTypeEnumA      ModifyRecordBodyTypeEnum = "A"
+	ModifyRecordBodyTypeEnumAaaa   ModifyRecordBodyTypeEnum = "AAAA"
+	ModifyRecordBodyTypeEnumCaa    ModifyRecordBodyTypeEnum = "CAA"
+	ModifyRecordBodyTypeEnumCmauth ModifyRecordBodyTypeEnum = "CMAUTH"
+	ModifyRecordBodyTypeEnumCname  ModifyRecordBodyTypeEnum = "CNAME"
+	ModifyRecordBodyTypeEnumMx     ModifyRecordBodyTypeEnum = "MX"
+	ModifyRecordBodyTypeEnumNs     ModifyRecordBodyTypeEnum = "NS"
+	ModifyRecordBodyTypeEnumPtr    ModifyRecordBodyTypeEnum = "PTR"
+	ModifyRecordBodyTypeEnumRp     ModifyRecordBodyTypeEnum = "RP"
+	ModifyRecordBodyTypeEnumSpf    ModifyRecordBodyTypeEnum = "SPF"
+	ModifyRecordBodyTypeEnumSrv    ModifyRecordBodyTypeEnum = "SRV"
+	ModifyRecordBodyTypeEnumTxt    ModifyRecordBodyTypeEnum = "TXT"
+	ModifyRecordBodyTypeEnumUrl    ModifyRecordBodyTypeEnum = "URL"
 )
 
 type ModifyRecordBody struct {
-    position.Body
+	position.Body
 	// 解析记录ID
 	RecordId string `json:"recordId"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_openapi_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_openapi_body.go
@@ -5,26 +5,27 @@
 package model
 
 import (
-    "gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
+	"gitlab.ecloud.com/ecloud/ecloudsdkcore/position"
 )
+
 type ModifyRecordOpenapiBodyTypeEnum string
 
 // List of Type
 const (
-    ModifyRecordOpenapiBodyTypeEnumA ModifyRecordOpenapiBodyTypeEnum = "A"
-    ModifyRecordOpenapiBodyTypeEnumAaaa ModifyRecordOpenapiBodyTypeEnum = "AAAA"
-    ModifyRecordOpenapiBodyTypeEnumCname ModifyRecordOpenapiBodyTypeEnum = "CNAME"
-    ModifyRecordOpenapiBodyTypeEnumMx ModifyRecordOpenapiBodyTypeEnum = "MX"
-    ModifyRecordOpenapiBodyTypeEnumTxt ModifyRecordOpenapiBodyTypeEnum = "TXT"
-    ModifyRecordOpenapiBodyTypeEnumNs ModifyRecordOpenapiBodyTypeEnum = "NS"
-    ModifyRecordOpenapiBodyTypeEnumSpf ModifyRecordOpenapiBodyTypeEnum = "SPF"
-    ModifyRecordOpenapiBodyTypeEnumSrv ModifyRecordOpenapiBodyTypeEnum = "SRV"
-    ModifyRecordOpenapiBodyTypeEnumCaa ModifyRecordOpenapiBodyTypeEnum = "CAA"
-    ModifyRecordOpenapiBodyTypeEnumCmauth ModifyRecordOpenapiBodyTypeEnum = "CMAUTH"
+	ModifyRecordOpenapiBodyTypeEnumA      ModifyRecordOpenapiBodyTypeEnum = "A"
+	ModifyRecordOpenapiBodyTypeEnumAaaa   ModifyRecordOpenapiBodyTypeEnum = "AAAA"
+	ModifyRecordOpenapiBodyTypeEnumCname  ModifyRecordOpenapiBodyTypeEnum = "CNAME"
+	ModifyRecordOpenapiBodyTypeEnumMx     ModifyRecordOpenapiBodyTypeEnum = "MX"
+	ModifyRecordOpenapiBodyTypeEnumTxt    ModifyRecordOpenapiBodyTypeEnum = "TXT"
+	ModifyRecordOpenapiBodyTypeEnumNs     ModifyRecordOpenapiBodyTypeEnum = "NS"
+	ModifyRecordOpenapiBodyTypeEnumSpf    ModifyRecordOpenapiBodyTypeEnum = "SPF"
+	ModifyRecordOpenapiBodyTypeEnumSrv    ModifyRecordOpenapiBodyTypeEnum = "SRV"
+	ModifyRecordOpenapiBodyTypeEnumCaa    ModifyRecordOpenapiBodyTypeEnum = "CAA"
+	ModifyRecordOpenapiBodyTypeEnumCmauth ModifyRecordOpenapiBodyTypeEnum = "CMAUTH"
 )
 
 type ModifyRecordOpenapiBody struct {
-    position.Body
+	position.Body
 	// 解析记录ID
 	RecordId string `json:"recordId"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_openapi_request.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_openapi_request.go
@@ -4,9 +4,6 @@
 
 package model
 
-
-
 type ModifyRecordOpenapiRequest struct {
-
 	ModifyRecordOpenapiBody *ModifyRecordOpenapiBody `json:"modifyRecordOpenapiBody,omitempty"`
 }

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_openapi_response.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_openapi_response.go
@@ -4,19 +4,17 @@
 
 package model
 
-
 type ModifyRecordOpenapiResponseStateEnum string
 
 // List of State
 const (
-    ModifyRecordOpenapiResponseStateEnumError ModifyRecordOpenapiResponseStateEnum = "ERROR"
-    ModifyRecordOpenapiResponseStateEnumException ModifyRecordOpenapiResponseStateEnum = "EXCEPTION"
-    ModifyRecordOpenapiResponseStateEnumForbidden ModifyRecordOpenapiResponseStateEnum = "FORBIDDEN"
-    ModifyRecordOpenapiResponseStateEnumOk ModifyRecordOpenapiResponseStateEnum = "OK"
+	ModifyRecordOpenapiResponseStateEnumError     ModifyRecordOpenapiResponseStateEnum = "ERROR"
+	ModifyRecordOpenapiResponseStateEnumException ModifyRecordOpenapiResponseStateEnum = "EXCEPTION"
+	ModifyRecordOpenapiResponseStateEnumForbidden ModifyRecordOpenapiResponseStateEnum = "FORBIDDEN"
+	ModifyRecordOpenapiResponseStateEnumOk        ModifyRecordOpenapiResponseStateEnum = "OK"
 )
 
 type ModifyRecordOpenapiResponse struct {
-
 	RequestId string `json:"requestId,omitempty"`
 
 	ErrorMessage string `json:"errorMessage,omitempty"`

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_openapi_response_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_openapi_response_body.go
@@ -4,40 +4,40 @@
 
 package model
 
-
 type ModifyRecordOpenapiResponseBodyTypeEnum string
 
 // List of Type
 const (
-    ModifyRecordOpenapiResponseBodyTypeEnumA ModifyRecordOpenapiResponseBodyTypeEnum = "A"
-    ModifyRecordOpenapiResponseBodyTypeEnumAaaa ModifyRecordOpenapiResponseBodyTypeEnum = "AAAA"
-    ModifyRecordOpenapiResponseBodyTypeEnumCname ModifyRecordOpenapiResponseBodyTypeEnum = "CNAME"
-    ModifyRecordOpenapiResponseBodyTypeEnumMx ModifyRecordOpenapiResponseBodyTypeEnum = "MX"
-    ModifyRecordOpenapiResponseBodyTypeEnumTxt ModifyRecordOpenapiResponseBodyTypeEnum = "TXT"
-    ModifyRecordOpenapiResponseBodyTypeEnumNs ModifyRecordOpenapiResponseBodyTypeEnum = "NS"
-    ModifyRecordOpenapiResponseBodyTypeEnumSpf ModifyRecordOpenapiResponseBodyTypeEnum = "SPF"
-    ModifyRecordOpenapiResponseBodyTypeEnumSrv ModifyRecordOpenapiResponseBodyTypeEnum = "SRV"
-    ModifyRecordOpenapiResponseBodyTypeEnumCaa ModifyRecordOpenapiResponseBodyTypeEnum = "CAA"
-    ModifyRecordOpenapiResponseBodyTypeEnumCmauth ModifyRecordOpenapiResponseBodyTypeEnum = "CMAUTH"
+	ModifyRecordOpenapiResponseBodyTypeEnumA      ModifyRecordOpenapiResponseBodyTypeEnum = "A"
+	ModifyRecordOpenapiResponseBodyTypeEnumAaaa   ModifyRecordOpenapiResponseBodyTypeEnum = "AAAA"
+	ModifyRecordOpenapiResponseBodyTypeEnumCname  ModifyRecordOpenapiResponseBodyTypeEnum = "CNAME"
+	ModifyRecordOpenapiResponseBodyTypeEnumMx     ModifyRecordOpenapiResponseBodyTypeEnum = "MX"
+	ModifyRecordOpenapiResponseBodyTypeEnumTxt    ModifyRecordOpenapiResponseBodyTypeEnum = "TXT"
+	ModifyRecordOpenapiResponseBodyTypeEnumNs     ModifyRecordOpenapiResponseBodyTypeEnum = "NS"
+	ModifyRecordOpenapiResponseBodyTypeEnumSpf    ModifyRecordOpenapiResponseBodyTypeEnum = "SPF"
+	ModifyRecordOpenapiResponseBodyTypeEnumSrv    ModifyRecordOpenapiResponseBodyTypeEnum = "SRV"
+	ModifyRecordOpenapiResponseBodyTypeEnumCaa    ModifyRecordOpenapiResponseBodyTypeEnum = "CAA"
+	ModifyRecordOpenapiResponseBodyTypeEnumCmauth ModifyRecordOpenapiResponseBodyTypeEnum = "CMAUTH"
 )
+
 type ModifyRecordOpenapiResponseBodyTimedStatusEnum string
 
 // List of TimedStatus
 const (
-    ModifyRecordOpenapiResponseBodyTimedStatusEnumDisabled ModifyRecordOpenapiResponseBodyTimedStatusEnum = "DISABLED"
-    ModifyRecordOpenapiResponseBodyTimedStatusEnumEnabled ModifyRecordOpenapiResponseBodyTimedStatusEnum = "ENABLED"
-    ModifyRecordOpenapiResponseBodyTimedStatusEnumTimed ModifyRecordOpenapiResponseBodyTimedStatusEnum = "TIMED"
+	ModifyRecordOpenapiResponseBodyTimedStatusEnumDisabled ModifyRecordOpenapiResponseBodyTimedStatusEnum = "DISABLED"
+	ModifyRecordOpenapiResponseBodyTimedStatusEnumEnabled  ModifyRecordOpenapiResponseBodyTimedStatusEnum = "ENABLED"
+	ModifyRecordOpenapiResponseBodyTimedStatusEnumTimed    ModifyRecordOpenapiResponseBodyTimedStatusEnum = "TIMED"
 )
+
 type ModifyRecordOpenapiResponseBodyStateEnum string
 
 // List of State
 const (
-    ModifyRecordOpenapiResponseBodyStateEnumDisabled ModifyRecordOpenapiResponseBodyStateEnum = "DISABLED"
-    ModifyRecordOpenapiResponseBodyStateEnumEnabled ModifyRecordOpenapiResponseBodyStateEnum = "ENABLED"
+	ModifyRecordOpenapiResponseBodyStateEnumDisabled ModifyRecordOpenapiResponseBodyStateEnum = "DISABLED"
+	ModifyRecordOpenapiResponseBodyStateEnumEnabled  ModifyRecordOpenapiResponseBodyStateEnum = "ENABLED"
 )
 
 type ModifyRecordOpenapiResponseBody struct {
-
 	// 主机头
 	Rr string `json:"rr,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_openapi_response_tags.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_openapi_response_tags.go
@@ -4,10 +4,7 @@
 
 package model
 
-
-
 type ModifyRecordOpenapiResponseTags struct {
-
 	// 标签ID
 	TagId string `json:"tagId,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_request.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_request.go
@@ -4,9 +4,6 @@
 
 package model
 
-
-
 type ModifyRecordRequest struct {
-
 	ModifyRecordBody *ModifyRecordBody `json:"modifyRecordBody,omitempty"`
 }

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_response.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_response.go
@@ -4,19 +4,17 @@
 
 package model
 
-
 type ModifyRecordResponseStateEnum string
 
 // List of State
 const (
-    ModifyRecordResponseStateEnumError ModifyRecordResponseStateEnum = "ERROR"
-    ModifyRecordResponseStateEnumException ModifyRecordResponseStateEnum = "EXCEPTION"
-    ModifyRecordResponseStateEnumForbidden ModifyRecordResponseStateEnum = "FORBIDDEN"
-    ModifyRecordResponseStateEnumOk ModifyRecordResponseStateEnum = "OK"
+	ModifyRecordResponseStateEnumError     ModifyRecordResponseStateEnum = "ERROR"
+	ModifyRecordResponseStateEnumException ModifyRecordResponseStateEnum = "EXCEPTION"
+	ModifyRecordResponseStateEnumForbidden ModifyRecordResponseStateEnum = "FORBIDDEN"
+	ModifyRecordResponseStateEnumOk        ModifyRecordResponseStateEnum = "OK"
 )
 
 type ModifyRecordResponse struct {
-
 	RequestId string `json:"requestId,omitempty"`
 
 	ErrorMessage string `json:"errorMessage,omitempty"`

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_response_body.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkclouddns@v1.0.1/model/modify_record_response_body.go
@@ -4,35 +4,34 @@
 
 package model
 
-
 type ModifyRecordResponseBodyTypeEnum string
 
 // List of Type
 const (
-    ModifyRecordResponseBodyTypeEnumA ModifyRecordResponseBodyTypeEnum = "A"
-    ModifyRecordResponseBodyTypeEnumAaaa ModifyRecordResponseBodyTypeEnum = "AAAA"
-    ModifyRecordResponseBodyTypeEnumCaa ModifyRecordResponseBodyTypeEnum = "CAA"
-    ModifyRecordResponseBodyTypeEnumCmauth ModifyRecordResponseBodyTypeEnum = "CMAUTH"
-    ModifyRecordResponseBodyTypeEnumCname ModifyRecordResponseBodyTypeEnum = "CNAME"
-    ModifyRecordResponseBodyTypeEnumMx ModifyRecordResponseBodyTypeEnum = "MX"
-    ModifyRecordResponseBodyTypeEnumNs ModifyRecordResponseBodyTypeEnum = "NS"
-    ModifyRecordResponseBodyTypeEnumPtr ModifyRecordResponseBodyTypeEnum = "PTR"
-    ModifyRecordResponseBodyTypeEnumRp ModifyRecordResponseBodyTypeEnum = "RP"
-    ModifyRecordResponseBodyTypeEnumSpf ModifyRecordResponseBodyTypeEnum = "SPF"
-    ModifyRecordResponseBodyTypeEnumSrv ModifyRecordResponseBodyTypeEnum = "SRV"
-    ModifyRecordResponseBodyTypeEnumTxt ModifyRecordResponseBodyTypeEnum = "TXT"
-    ModifyRecordResponseBodyTypeEnumUrl ModifyRecordResponseBodyTypeEnum = "URL"
+	ModifyRecordResponseBodyTypeEnumA      ModifyRecordResponseBodyTypeEnum = "A"
+	ModifyRecordResponseBodyTypeEnumAaaa   ModifyRecordResponseBodyTypeEnum = "AAAA"
+	ModifyRecordResponseBodyTypeEnumCaa    ModifyRecordResponseBodyTypeEnum = "CAA"
+	ModifyRecordResponseBodyTypeEnumCmauth ModifyRecordResponseBodyTypeEnum = "CMAUTH"
+	ModifyRecordResponseBodyTypeEnumCname  ModifyRecordResponseBodyTypeEnum = "CNAME"
+	ModifyRecordResponseBodyTypeEnumMx     ModifyRecordResponseBodyTypeEnum = "MX"
+	ModifyRecordResponseBodyTypeEnumNs     ModifyRecordResponseBodyTypeEnum = "NS"
+	ModifyRecordResponseBodyTypeEnumPtr    ModifyRecordResponseBodyTypeEnum = "PTR"
+	ModifyRecordResponseBodyTypeEnumRp     ModifyRecordResponseBodyTypeEnum = "RP"
+	ModifyRecordResponseBodyTypeEnumSpf    ModifyRecordResponseBodyTypeEnum = "SPF"
+	ModifyRecordResponseBodyTypeEnumSrv    ModifyRecordResponseBodyTypeEnum = "SRV"
+	ModifyRecordResponseBodyTypeEnumTxt    ModifyRecordResponseBodyTypeEnum = "TXT"
+	ModifyRecordResponseBodyTypeEnumUrl    ModifyRecordResponseBodyTypeEnum = "URL"
 )
+
 type ModifyRecordResponseBodyStateEnum string
 
 // List of State
 const (
-    ModifyRecordResponseBodyStateEnumDisabled ModifyRecordResponseBodyStateEnum = "DISABLED"
-    ModifyRecordResponseBodyStateEnumEnabled ModifyRecordResponseBodyStateEnum = "ENABLED"
+	ModifyRecordResponseBodyStateEnumDisabled ModifyRecordResponseBodyStateEnum = "DISABLED"
+	ModifyRecordResponseBodyStateEnumEnabled  ModifyRecordResponseBodyStateEnum = "ENABLED"
 )
 
 type ModifyRecordResponseBody struct {
-
 	// 主机头
 	Rr string `json:"rr,omitempty"`
 

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkcore@v1.0.0/api_client.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkcore@v1.0.0/api_client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"gitlab.ecloud.com/ecloud/ecloudsdkcore/config"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -20,6 +19,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"gitlab.ecloud.com/ecloud/ecloudsdkcore/config"
 )
 
 var (
@@ -47,8 +48,10 @@ const (
 	HEADER HttpRequestPosition = "Header"
 )
 
-const SdkPortalUrl = "/op-apim-portal/apim/request/sdk"
-const SdkPortalGatewayUrl = "/api/query/openapi/apim/request/sdk"
+const (
+	SdkPortalUrl        = "/op-apim-portal/apim/request/sdk"
+	SdkPortalGatewayUrl = "/api/query/openapi/apim/request/sdk"
+)
 
 // NewAPIClient creates a new API client.
 func NewAPIClient() *APIClient {
@@ -199,7 +202,7 @@ func buildHttpRequest(httpRequest *HttpRequest, config *config.Config) *HttpRequ
 		if v.Kind() == reflect.Ptr {
 			v = v.Elem()
 		}
-		var flag = false
+		flag := false
 		for i := 0; i < reqType.NumField(); i++ {
 			fieldType := reqType.Field(i)
 			value := v.FieldByName(fieldType.Name)
@@ -270,7 +273,7 @@ func structToMap(value interface{}) map[string]interface{} {
 }
 
 func buildCall(httpRequest *HttpRequest) (request *http.Request) {
-	var url = ""
+	url := ""
 	if len(httpRequest.Url) > 0 {
 		url = httpRequest.Url + SdkPortalUrl
 	} else {
@@ -284,12 +287,11 @@ func buildCall(httpRequest *HttpRequest) (request *http.Request) {
 func prepareRequest(path string, method string,
 	postBody interface{},
 ) (httpRequest *http.Request, err error) {
-
 	var body *bytes.Buffer
 
 	// Detect postBody type and post.
 	if postBody != nil {
-		var contentType = detectContentType(postBody)
+		contentType := detectContentType(postBody)
 		body, err = setBody(postBody, contentType)
 		if err != nil {
 			return nil, err

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkcore@v1.0.0/api_response.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkcore@v1.0.0/api_response.go
@@ -52,13 +52,11 @@ type APIPlatformResponseBody struct {
 }
 
 func NewAPIResponse(r *http.Response) *APIResponse {
-
 	response := &APIResponse{Response: r}
 	return response
 }
 
 func NewAPIResponseWithError(errorMessage string) *APIResponse {
-
 	response := &APIResponse{Message: errorMessage}
 	return response
 }

--- a/internal/pkg/vendors/cmcc-sdk/ecloudsdkcore@v1.0.0/position/http_position.go
+++ b/internal/pkg/vendors/cmcc-sdk/ecloudsdkcore@v1.0.0/position/http_position.go
@@ -1,13 +1,9 @@
 package position
 
-type Body struct {
-}
+type Body struct{}
 
-type Query struct {
-}
+type Query struct{}
 
-type Path struct {
-}
+type Path struct{}
 
-type Header struct {
-}
+type Header struct{}

--- a/internal/pkg/vendors/dogecloud-sdk/client.go
+++ b/internal/pkg/vendors/dogecloud-sdk/client.go
@@ -1,4 +1,4 @@
-﻿package dogecloudsdk
+package dogecloudsdk
 
 import (
 	"crypto/hmac"

--- a/internal/pkg/vendors/dogecloud-sdk/models.go
+++ b/internal/pkg/vendors/dogecloud-sdk/models.go
@@ -1,4 +1,4 @@
-﻿package dogecloudsdk
+package dogecloudsdk
 
 type BaseResponse struct {
 	Code    *int    `json:"code,omitempty"`

--- a/internal/pkg/vendors/gcore-sdk/common/endpoint.go
+++ b/internal/pkg/vendors/gcore-sdk/common/endpoint.go
@@ -1,3 +1,3 @@
-﻿package common
+package common
 
 const BASE_URL = "https://api.gcore.com"

--- a/internal/pkg/vendors/gcore-sdk/common/signer.go
+++ b/internal/pkg/vendors/gcore-sdk/common/signer.go
@@ -1,4 +1,4 @@
-﻿package common
+package common
 
 import (
 	"net/http"

--- a/internal/pkg/vendors/huaweicloud-sdk/cast.go
+++ b/internal/pkg/vendors/huaweicloud-sdk/cast.go
@@ -1,4 +1,4 @@
-﻿package huaweicloudsdk
+package huaweicloudsdk
 
 func Int32Ptr(i int32) *int32 {
 	return &i

--- a/internal/pkg/vendors/qiniu-sdk/client.go
+++ b/internal/pkg/vendors/qiniu-sdk/client.go
@@ -1,4 +1,4 @@
-﻿package qiniusdk
+package qiniusdk
 
 import (
 	"context"

--- a/internal/pkg/vendors/qiniu-sdk/models.go
+++ b/internal/pkg/vendors/qiniu-sdk/models.go
@@ -1,4 +1,4 @@
-﻿package qiniusdk
+package qiniusdk
 
 type BaseResponse struct {
 	Code  *int    `json:"code,omitempty"`

--- a/internal/pkg/vendors/ucloud-sdk/ufile/apis.go
+++ b/internal/pkg/vendors/ucloud-sdk/ufile/apis.go
@@ -1,4 +1,4 @@
-﻿package ufile
+package ufile
 
 import (
 	"github.com/ucloud/ucloud-sdk-go/ucloud/request"

--- a/internal/pkg/vendors/ucloud-sdk/ufile/client.go
+++ b/internal/pkg/vendors/ucloud-sdk/ufile/client.go
@@ -1,4 +1,4 @@
-﻿package ufile
+package ufile
 
 import (
 	"github.com/ucloud/ucloud-sdk-go/ucloud"

--- a/internal/pkg/vendors/ucloud-sdk/ussl/apis.go
+++ b/internal/pkg/vendors/ucloud-sdk/ussl/apis.go
@@ -1,4 +1,4 @@
-﻿package ussl
+package ussl
 
 import (
 	"github.com/ucloud/ucloud-sdk-go/ucloud/request"

--- a/internal/pkg/vendors/ucloud-sdk/ussl/client.go
+++ b/internal/pkg/vendors/ucloud-sdk/ussl/client.go
@@ -1,4 +1,4 @@
-﻿package ussl
+package ussl
 
 import (
 	"github.com/ucloud/ucloud-sdk-go/ucloud"

--- a/internal/pkg/vendors/ucloud-sdk/ussl/models.go
+++ b/internal/pkg/vendors/ucloud-sdk/ussl/models.go
@@ -1,4 +1,4 @@
-﻿package ussl
+package ussl
 
 type CertificateListItem struct {
 	CertificateID     int

--- a/internal/pkg/vendors/volcengine-sdk/certcenter/api_import_certificate.go
+++ b/internal/pkg/vendors/volcengine-sdk/certcenter/api_import_certificate.go
@@ -1,4 +1,4 @@
-﻿package certcenter
+package certcenter
 
 import (
 	"github.com/volcengine/volcengine-go-sdk/volcengine"

--- a/internal/pkg/vendors/volcengine-sdk/certcenter/interface.go
+++ b/internal/pkg/vendors/volcengine-sdk/certcenter/interface.go
@@ -1,4 +1,4 @@
-﻿package certcenter
+package certcenter
 
 import (
 	"github.com/volcengine/volcengine-go-sdk/volcengine"

--- a/internal/pkg/vendors/volcengine-sdk/certcenter/service.go
+++ b/internal/pkg/vendors/volcengine-sdk/certcenter/service.go
@@ -1,4 +1,4 @@
-﻿package certcenter
+package certcenter
 
 import (
 	"github.com/volcengine/volcengine-go-sdk/volcengine"

--- a/internal/workflow/dispatcher/dispatcher.go
+++ b/internal/workflow/dispatcher/dispatcher.go
@@ -1,4 +1,4 @@
-﻿package dispatcher
+package dispatcher
 
 import (
 	"context"

--- a/internal/workflow/dispatcher/singleton.go
+++ b/internal/workflow/dispatcher/singleton.go
@@ -1,4 +1,4 @@
-﻿package dispatcher
+package dispatcher
 
 import (
 	"context"


### PR DESCRIPTION
在 CONTRIBUTING.md 里有提到

> 使用 [gofumpt](https://github.com/mvdan/gofumpt) 对你的代码进行格式化。

但似乎并没有人这么做

代码里充满了 UTF-8 BOM 文件头，部分 Go 的代码没有格式化

此 PR 为在项目根目录运行 `gofumpt -l -w .` 的结果