### PR TITLE
add support for the env TZ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN go build -o certimate
 
 
 FROM alpine:latest
+ENV TZ UTC
+RUN apk add tzdata
 WORKDIR /app
 COPY --from=builder /app/certimate .
 ENTRYPOINT ["./certimate", "serve", "--http", "0.0.0.0:8090"]


### PR DESCRIPTION
新增容器对环境变量`TZ`的支持，考虑到项目的通用性，所以默认时区还是保持`UTC`不变