### PR TITLE
Google ACME Proxy [实验性拓展]

### DIFF
--- a/internal/applicant/acme_ca.go
+++ b/internal/applicant/acme_ca.go
@@ -24,6 +24,21 @@ var sslProviderUrls = map[string]string{
 	sslProviderZeroSSL:             "https://acme.zerossl.com/v2/DV90",
 }
 
+func getCAProviderURL(providerType string, config map[string]any) string {
+	baseURL, ok := sslProviderUrls[providerType]
+	if !ok {
+		return sslProviderUrls[sslProviderDefault]
+	}
+
+	if config != nil {
+		// 如果配置了代理域名，则替换URL
+		if proxyDomain, ok := config["proxyDomain"].(string); ok && proxyDomain != "" {
+			return proxyDomain
+		}
+	}
+	return baseURL
+}
+
 type acmeSSLProviderConfig struct {
 	Config   map[domain.CAProviderType]map[string]any `json:"config"`
 	Provider string                                   `json:"provider"`

--- a/internal/applicant/applicant.go
+++ b/internal/applicant/applicant.go
@@ -173,7 +173,8 @@ func applyUseLego(legoProvider challenge.Provider, options *applicantProviderOpt
 	// Create an ACME client config
 	config := lego.NewConfig(user)
 	config.Certificate.KeyType = parseLegoKeyAlgorithm(domain.CertificateKeyAlgorithmType(options.KeyAlgorithm))
-	config.CADirURL = sslProviderUrls[user.CA]
+	//config.CADirURL = sslProviderUrls[user.CA]
+	config.CADirURL = getCAProviderURL(user.CA, options.CAProviderAccessConfig)
 	if user.CA == sslProviderSSLCom {
 		if strings.HasPrefix(options.KeyAlgorithm, "RSA") {
 			config.CADirURL = sslProviderUrls[sslProviderSSLCom+"RSA"]

--- a/internal/domain/access.go
+++ b/internal/domain/access.go
@@ -229,8 +229,9 @@ type AccessConfigForSSH struct {
 }
 
 type AccessConfigForSSLCom struct {
-	EabKid     string `json:"eabKid"`
-	EabHmacKey string `json:"eabHmacKey"`
+	EabKid      string `json:"eabKid"`
+	EabHmacKey  string `json:"eabHmacKey"`
+	ProxyDomain string `json:"proxyDomain"`
 }
 
 type AccessConfigForTelegram struct {

--- a/ui/src/components/access/AccessFormGoogleTrustServicesConfig.tsx
+++ b/ui/src/components/access/AccessFormGoogleTrustServicesConfig.tsx
@@ -4,6 +4,7 @@ import { createSchemaFieldRule } from "antd-zod";
 import { z } from "zod";
 
 import { type AccessConfigForGoogleTrustServices } from "@/domain/access";
+import { validDomainName } from "@/utils/validators";
 
 type AccessFormGoogleTrustServicesConfigFieldValues = Nullish<AccessConfigForGoogleTrustServices>;
 
@@ -19,6 +20,7 @@ const initFormModel = (): AccessFormGoogleTrustServicesConfigFieldValues => {
   return {
     eabKid: "",
     eabHmacKey: "",
+    proxyDomain: "",
   };
 };
 
@@ -42,6 +44,11 @@ const AccessFormGoogleTrustServicesConfig = ({
       .min(1, t("access.form.googletrustservices_eab_hmac_key.placeholder"))
       .max(256, t("common.errmsg.string_max", { max: 256 }))
       .trim(),
+    proxyDomain: z
+      .string()
+      .trim()
+      .refine((v) => v === "" ||v.startsWith("https://") && validDomainName(v.split('/')[2], { allowWildcard: true }), t("common.errmsg.domain_invalid"))
+      .optional(),
   });
   const formRule = createSchemaFieldRule(formSchema);
 
@@ -75,6 +82,17 @@ const AccessFormGoogleTrustServicesConfig = ({
       >
         <Input.Password autoComplete="new-password" placeholder={t("access.form.googletrustservices_eab_hmac_key.placeholder")} />
       </Form.Item>
+
+      <Form.Item
+            name="proxyDomain"
+            label={t("access.form.googletrustservices_proxy.label")}
+            rules={[formRule]}
+            tooltip={<span dangerouslySetInnerHTML={{ __html: t("access.form.googletrustservices_proxy.tooltip") }}></span>}
+            required={false}
+          >
+            <Input placeholder="https://acme.example.com/directory" />
+      </Form.Item>
+
     </Form>
   );
 };

--- a/ui/src/domain/access.ts
+++ b/ui/src/domain/access.ts
@@ -197,6 +197,7 @@ export type AccessConfigForGoDaddy = {
 export type AccessConfigForGoogleTrustServices = {
   eabKid: string;
   eabHmacKey: string;
+  proxyDomain: string;
 };
 
 export type AccessConfigForHuaweiCloud = {

--- a/ui/src/i18n/locales/en/nls.access.json
+++ b/ui/src/i18n/locales/en/nls.access.json
@@ -206,6 +206,8 @@
   "access.form.googletrustservices_eab_hmac_key.label": "ACME EAB HMAC key",
   "access.form.googletrustservices_eab_hmac_key.placeholder": "Please enter ACME EAB HMAC key",
   "access.form.googletrustservices_eab_hmac_key.tooltip": "For more information, see <a href=\"https://cloud.google.com/certificate-manager/docs/public-ca-tutorial\" target=\"_blank\">https://cloud.google.com/certificate-manager/docs/public-ca-tutorial</a>",
+  "access.form.googletrustservices_proxy.label": "Proxy address (Optional)",
+  "access.form.googletrustservices_proxy.tooltip": "Optional proxy address name for certificate requests, see <a href=\"https://github.com/bigbugcc/Acme-CFWorker\" target=\"_blank\">https://github.com/bigbugcc/Acme-CFWorker</a>",
   "access.form.huaweicloud_access_key_id.label": "Huawei Cloud AccessKeyId",
   "access.form.huaweicloud_access_key_id.placeholder": "Please enter Huawei Cloud AccessKeyId",
   "access.form.huaweicloud_access_key_id.tooltip": "For more information, see <a href=\"https://support.huaweicloud.com/intl/en-us/usermanual-ca/ca_01_0003.html\" target=\"_blank\">https://support.huaweicloud.com/intl/en-us/usermanual-ca/ca_01_0003.html</a>",

--- a/ui/src/i18n/locales/zh/nls.access.json
+++ b/ui/src/i18n/locales/zh/nls.access.json
@@ -199,6 +199,8 @@
   "access.form.googletrustservices_eab_kid.tooltip": "这是什么？请参阅 <a href=\"https://cloud.google.com/certificate-manager/docs/public-ca-tutorial\" target=\"_blank\">https://cloud.google.com/certificate-manager/docs/public-ca-tutorial</a>",
   "access.form.googletrustservices_eab_hmac_key.label": "ACME EAB HMAC Key",
   "access.form.googletrustservices_eab_hmac_key.placeholder": "请输入 ACME EAB HMAC Key",
+  "access.form.googletrustservices_proxy.label": "代理地址（可选）",
+  "access.form.googletrustservices_proxy.tooltip": "用于证书请求的可选代理地址，请参阅 <a href=\"https://github.com/bigbugcc/Acme-CFWorker\" target=\"_blank\">https://github.com/bigbugcc/Acme-CFWorker</a>",
   "access.form.googletrustservices_eab_hmac_key.tooltip": "这是什么？请参阅 <a href=\"https://cloud.google.com/certificate-manager/docs/public-ca-tutorial\" target=\"_blank\">https://cloud.google.com/certificate-manager/docs/public-ca-tutorial</a>",
   "access.form.huaweicloud_access_key_id.label": "华为云 AccessKeyId",
   "access.form.huaweicloud_access_key_id.placeholder": "请输入华为云 AccessKeyId",


### PR DESCRIPTION
在原有的申请签发流程加入透明代理转发签证的请求(可选项)，
![jws-error](https://github.com/user-attachments/assets/514930c0-63e9-4be8-b2d5-837924cdaa77)
但是过程遇到**请求地址**与**目的地址**不一致，导致google校验JWS签名失败返回400错误，项目中关于jws签名部分是引用的lego，此处不知怎么做会好点？