### PR TITLE
chore: add ui/dist/.gitkeep file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ git clone https://github.com/your_username/certimate.git
 
 这将启动一个 Web 服务器，默认运行在 `http://localhost:8090`，并使用来自 `ui/dist` 的预构建管理页面。
 
+> 如果你遇到报错 `ui/embed.go:10:12: pattern all:dist: no matching files found` 请先参考 [构建 Admin UI](#修改管理页面-admin-ui)
+
 **在向主仓库提交 PR 之前，建议你：**
 
 - 使用 [gofumpt](https://github.com/mvdan/gofumpt) 对你的代码进行格式化。

--- a/CONTRIBUTING_EN.md
+++ b/CONTRIBUTING_EN.md
@@ -36,6 +36,8 @@ Once you have made changes to the Go code in Certimate, follow these steps to ru
 
 This will start a web server at `http://localhost:8090` using the prebuilt Admin UI located in `ui/dist`.
 
+> if you encounter an error `ui/embed.go:10:12: pattern all:dist: no matching files found`, please refer to [build Admin UI](#making-changes-in-the-admin-ui)
+
 **Before submitting a PR to the main repository, consider:**
 
 - Format your source code by using [gofumpt](https://github.com/mvdan/gofumpt).


### PR DESCRIPTION
# 问题
参考贡献相关文档 <https://github.com/usual2970/certimate/blob/main/CONTRIBUTING.md#%E4%BF%AE%E6%94%B9-go-%E4%BB%A3%E7%A0%81>
新 clone 仓库在直接执行 `go run main.go serve` 会报错 `ui/embed.go:10:12: pattern all:dist: no matching files found`

# 方案
为 `ui/dist` 文件夹添加 `.gitkeep` 以保持 git 跟踪此文件夹，可以避免仅启动后端调试时未编译前端会无法启动

TBR; @fudiwei @usual2970 