### PR TITLE
fix: correct certificate expiration check logic

### DIFF
--- a/ui/src/i18n/locales/en/nls.certificate.json
+++ b/ui/src/i18n/locales/en/nls.certificate.json
@@ -13,6 +13,7 @@
   "certificate.props.subject_alt_names": "Name",
   "certificate.props.validity": "Expiry",
   "certificate.props.validity.left_days": "{{left}} / {{total}} days left",
+  "certificate.props.validity.less_than_day": "Expire soon ({{hours}} hours left)",
   "certificate.props.validity.expired": "Expired",
   "certificate.props.validity.expiration": "Expire on {{date}}",
   "certificate.props.validity.filter.expire_soon": "Expire soon",

--- a/ui/src/i18n/locales/zh/nls.certificate.json
+++ b/ui/src/i18n/locales/zh/nls.certificate.json
@@ -13,6 +13,7 @@
   "certificate.props.subject_alt_names": "名称",
   "certificate.props.validity": "有效期限",
   "certificate.props.validity.left_days": "{{left}} / {{total}} 天",
+  "certificate.props.validity.less_than_day": "即将过期（剩余 {{hours}} 小时）",
   "certificate.props.validity.expired": "已到期",
   "certificate.props.validity.expiration": "{{date}} 到期",
   "certificate.props.validity.filter.expire_soon": "即将到期",

--- a/ui/src/pages/certificates/CertificateList.tsx
+++ b/ui/src/pages/certificates/CertificateList.tsx
@@ -109,11 +109,19 @@ const CertificateList = () => {
       },
       render: (_, record) => {
         const total = dayjs(record.expireAt).diff(dayjs(record.created), "d") + 1;
+        // 使用 isAfter 更精确地判断是否过期
+        const isExpired = dayjs().isAfter(dayjs(record.expireAt));
         const left = dayjs(record.expireAt).diff(dayjs(), "d");
+        const hours = dayjs(record.expireAt).diff(dayjs(), "h");
+
         return (
           <Space className="max-w-full" direction="vertical" size={4}>
-            {left > 0 ? (
-              <Typography.Text type="success">{t("certificate.props.validity.left_days", { left, total })}</Typography.Text>
+            {!isExpired ? (
+              left > 0 ? (
+                <Typography.Text type="success">{t("certificate.props.validity.left_days", { left, total })}</Typography.Text>
+              ) : (
+                <Typography.Text type="warning">{t("certificate.props.validity.less_than_day", { hours: hours > 0 ? hours : 1 })}</Typography.Text>
+              )
             ) : (
               <Typography.Text type="danger">{t("certificate.props.validity.expired")}</Typography.Text>
             )}

--- a/ui/src/repository/certificate.ts
+++ b/ui/src/repository/certificate.ts
@@ -18,7 +18,7 @@ export const list = async (request: ListRequest) => {
     filters.push(pb.filter("(subjectAltNames~{:keyword} || serialNumber={:keyword})", { keyword: request.keyword }));
   }
   if (request.state === "expireSoon") {
-    filters.push(pb.filter("expireAt<{:expiredAt}", { expiredAt: dayjs().add(20, "d").toDate() }));
+    filters.push(pb.filter("expireAt<{:expiredAt} && expireAt>@now", { expiredAt: dayjs().add(20, "d").toDate() }));
   } else if (request.state === "expired") {
     filters.push(pb.filter("expireAt<={:expiredAt}", { expiredAt: new Date() }));
   }


### PR DESCRIPTION
# 问题
1. 当前证书是否过期以天为维度进行比较，会导致剩余时间不足1天但尚未过期的证书显示为已过期。
2. 筛选即将过期证书时，会展示已过期的证书。

# 解决方案

1. 精确对比，对于不足1天的证书展示剩余小时数。
2. 筛选即将过期证书的时候，过滤掉已过期证书。